### PR TITLE
Fix kupmios provider

### DIFF
--- a/.changeset/ten-points-cover.md
+++ b/.changeset/ten-points-cover.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/provider": patch
+---
+
+Fix Kupmios provider errors on protocol params

--- a/packages/provider/src/kupmios.ts
+++ b/packages/provider/src/kupmios.ts
@@ -62,6 +62,11 @@ export class Kupmios implements Provider {
               priceStep: parseInt(stepsNum) / parseInt(stepsDenom),
               maxTxExMem: BigInt(result.maxExecutionUnitsPerTransaction.memory),
               maxTxExSteps: BigInt(result.maxExecutionUnitsPerTransaction.cpu),
+              // NOTE: coinsPerUtxoByte is now called utxoCostPerByte:
+              // https://github.com/IntersectMBO/cardano-node/pull/4141
+              // Ogmios v6.x calls it minUtxoDepositCoefficient according to the following
+              // documentation from its protocol parameters data model:
+              // https://github.com/CardanoSolutions/ogmios/blob/master/architectural-decisions/accepted/017-api-version-6-major-rewrite.md#protocol-parameters
               coinsPerUtxoByte: BigInt(result.minUtxoDepositCoefficient),
               collateralPercentage: parseInt(result.collateralPercentage),
               maxCollateralInputs: parseInt(result.maxCollateralInputs),


### PR DESCRIPTION
Fix Kupmios errors when getting protocol parameters by updating it to work with the current major version of Ogmios.
Added code comments for more clarity around the difference in property naming between Cardano ledger and Ogmios.

Tested against the following versions:

Cardano Node 8.9.0
Ogmios 6.1.0

Fixes #61 