### PR TITLE
Fix kupmios getDelegation call to Ogmios

### DIFF
--- a/.changeset/orange-pumpkins-pay.md
+++ b/.changeset/orange-pumpkins-pay.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/provider": patch
+---
+
+Fix Kupmios getDelegation call to Ogmios

--- a/packages/provider/src/kupmios.ts
+++ b/packages/provider/src/kupmios.ts
@@ -155,9 +155,10 @@ export class Kupmios implements Provider {
   }
 
   async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
-    const client = await this.ogmiosWsp("Query", {
-      query: { delegationsAndRewards: [rewardAddress] },
-    });
+    const client = await this.ogmiosWsp(
+      "queryLedgerState/rewardAccountSummaries",
+      { keys: [rewardAddress] },
+    );
 
     return new Promise((res, rej) => {
       client.addEventListener(
@@ -166,12 +167,13 @@ export class Kupmios implements Provider {
           try {
             const { result } = JSON.parse(msg.data);
             const delegation = (result ? Object.values(result)[0] : {}) as {
-              delegate: string;
-              rewards: number;
+              delegate: { id: string };
+              rewards: { ada: { lovelace: number } };
             };
+
             res({
-              poolId: delegation?.delegate || null,
-              rewards: BigInt(delegation?.rewards || 0),
+              poolId: delegation?.delegate?.id || null,
+              rewards: BigInt(delegation?.rewards?.ada?.lovelace || 0),
             });
             client.close();
           } catch (e) {


### PR DESCRIPTION
Fix Kupmios errors on `getDelegation` by updating it to work with the current major version of Ogmios.

Tested against the following versions:

Cardano Node 8.9.0
Ogmios 6.1.0

(preview testnet and mainnet)