### PR TITLE
Fix `assetsToValue` to support non UTF-8 Asset Names

### DIFF
--- a/.changeset/large-islands-help.md
+++ b/.changeset/large-islands-help.md
@@ -1,0 +1,6 @@
+---
+"@lucid-evolution/lucid": patch
+"@lucid-evolution/utils": patch
+---
+
+Fix assetsToValue to support non UTF-8 Asset Names

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,10 @@
 {
   description = "A Nix-flake-based Rust development environment";
 
+  nixConfig = {
+    bash-prompt = "\\[\\e[0;92m\\][\\[\\e[0;92m\\]nix develop:\\[\\e[0;92m\\]\\w\\[\\e[0;92m\\]]\\[\\e[0;92m\\]$ \\[\\e[0m\\]";
+  };
+
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 

--- a/packages/utils/src/value.ts
+++ b/packages/utils/src/value.ts
@@ -1,5 +1,5 @@
 import { Assets, PolicyId, Unit } from "@lucid-evolution/core-types";
-import { fromText, toText } from "@lucid-evolution/core-utils";
+import { fromHex, fromText, toText } from "@lucid-evolution/core-utils";
 import { CML } from "./core.js";
 import { fromLabel, toLabel } from "./label.js";
 
@@ -41,7 +41,7 @@ export function assetsToValue(assets: Assets): CML.Value {
     const assetsValue = CML.MapAssetNameToCoin.new();
     for (const unit of policyUnits) {
       assetsValue.insert(
-        CML.AssetName.from_str(toText(unit.slice(56))),
+        CML.AssetName.from_bytes(fromHex(unit.slice(56))),
         BigInt(assets[unit]),
       );
     }


### PR DESCRIPTION
`CML.AssetName.from_str` requires a UTF-8 string argument to convert it to `CML.AssetName`. It's not necessary that the hex encoded asset name (`unit.slice(56)`) is a valid UTF-8 string. The asset name could just be an arbitrary hex string without a valid UTF-8 encoding.