### PR TITLE
Fix reading from ogmios

### DIFF
--- a/packages/provider/src/kupmios.ts
+++ b/packages/provider/src/kupmios.ts
@@ -53,11 +53,11 @@ export class Kupmios implements Provider {
 
             res({
               minFeeA: parseInt(result.minFeeCoefficient),
-              minFeeB: parseInt(result.minFeeConstant.ada.lovelace),
+              minFeeB: parseInt(result.minFeeConstant.lovelace),
               maxTxSize: parseInt(result.maxTransactionSize.bytes),
               maxValSize: parseInt(result.maxValueSize.bytes),
-              keyDeposit: BigInt(result.stakeCredentialDeposit.ada.lovelace),
-              poolDeposit: BigInt(result.stakePoolDeposit.ada.lovelace),
+              keyDeposit: BigInt(result.stakeCredentialDeposit.lovelace),
+              poolDeposit: BigInt(result.stakePoolDeposit.lovelace),
               priceMem: parseInt(memNum) / parseInt(memDenom),
               priceStep: parseInt(stepsNum) / parseInt(stepsDenom),
               maxTxExMem: BigInt(result.maxExecutionUnitsPerTransaction.memory),


### PR DESCRIPTION
Currently ogmios provider is reading data from ogmios incorrectly.
This is a sample response from ogmios:
```
{
  "jsonrpc": "2.0",
  "method": "queryLedgerState/protocolParameters",
  "result": {
    "minFeeCoefficient": 44,
    "minFeeConstant": {
      "lovelace": 155381
    },
    "maxBlockBodySize": {
      "bytes": 90112
    },
    "maxBlockHeaderSize": {
      "bytes": 1100
    },
    "maxTransactionSize": {
      "bytes": 16384
    },
    "stakeCredentialDeposit": {
      "lovelace": 2000000
    },
    "stakePoolDeposit": {
      "lovelace": 500000000
    },
    "stakePoolRetirementEpochBound": 18,
    "desiredNumberOfStakePools": 500,
    "stakePoolPledgeInfluence": "3/10",
    "monetaryExpansion": "3/1000",
    "treasuryExpansion": "1/5",
    "minStakePoolCost": {
      "lovelace": 170000000
    },
    "minUtxoDepositConstant": 0,
    "minUtxoDepositCoefficient": 4310,
    ...[truncated]
  "id": null
}
```

While Kupmios is reading as `result.minFeeConstant.ada.lovelace` -> this cause error `Cannot read properties of undefined (reading 'lovelace')`