### PR TITLE
fix: remove paymentCredentialOf when querying utxos from providers

### DIFF
--- a/.changeset/tasty-cows-wash.md
+++ b/.changeset/tasty-cows-wash.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/wallet": patch
+---
+
+remove paymentCredentialOf when querying utxos from providers

--- a/packages/wallet/src/wallet_selection.ts
+++ b/packages/wallet/src/wallet_selection.ts
@@ -19,7 +19,6 @@ import {
   coreToUtxo,
   credentialToRewardAddress,
   getAddressDetails,
-  paymentCredentialOf,
   utxoToCore,
 } from "@lucid-evolution/utils";
 import { CML } from "./core.js";
@@ -78,7 +77,7 @@ export const makeWalletFromSeed = (
       const utxos =
         config.overriddenUTxOs.length > 0
           ? config.overriddenUTxOs
-          : await provider.getUtxos(paymentCredentialOf(address));
+          : await provider.getUtxos(address);
       const coreUtxos: CML.TransactionUnspentOutput[] = [];
       for (const utxo of utxos) {
         coreUtxos.push(utxoToCore(utxo));
@@ -164,12 +163,12 @@ export const makeWalletFromPrivateKey = (
     getUtxos: async (): Promise<UTxO[]> =>
       config.overriddenUTxOs.length > 0
         ? config.overriddenUTxOs
-        : provider.getUtxos(paymentCredentialOf(address)),
+        : provider.getUtxos(address),
     getUtxosCore: async (): Promise<CML.TransactionUnspentOutput[]> => {
       const utxos =
         config.overriddenUTxOs.length > 0
           ? config.overriddenUTxOs
-          : await provider.getUtxos(paymentCredentialOf(address));
+          : await provider.getUtxos(address);
       const coreUtxos: CML.TransactionUnspentOutput[] = [];
       for (const utxo of utxos) {
         coreUtxos.push(utxoToCore(utxo));
@@ -302,12 +301,12 @@ export const makeWalletFromAddress = (
     getUtxos: async (): Promise<UTxO[]> =>
       config.overriddenUTxOs.length > 0
         ? config.overriddenUTxOs
-        : provider.getUtxos(paymentCredentialOf(address)),
+        : provider.getUtxos(address),
     getUtxosCore: async (): Promise<CML.TransactionUnspentOutput[]> => {
       const utxos =
         config.overriddenUTxOs.length > 0
           ? config.overriddenUTxOs
-          : await provider.getUtxos(paymentCredentialOf(address));
+          : await provider.getUtxos(address);
       const coreUtxos: CML.TransactionUnspentOutput[] = [];
       for (const utxo of utxos) {
         coreUtxos.push(utxoToCore(utxo));


### PR DESCRIPTION
fix #202 