### PR TITLE
Remove Asset Units with Quantities of Zero

### DIFF
--- a/.changeset/young-boxes-push.md
+++ b/.changeset/young-boxes-push.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/utils": patch
+---
+
+removal of asset units with 0 quantity affter `addAssets`

--- a/packages/utils/src/value.ts
+++ b/packages/utils/src/value.ts
@@ -94,10 +94,11 @@ export function addAssets(...assets: Assets[]): Assets {
   return assets.reduce((a, b) => {
     for (const k in b) {
       if (Object.hasOwn(b, k)) {
-        if ((a[k] || 0n) + b[k] === 0n) {
+        const sum = (a[k] || 0n) + b[k];
+        if (sum === 0n) {
           delete a[k];
         } else {
-          a[k] = (a[k] || 0n) + b[k];
+          a[k] = sum;
         }
       }
     }

--- a/packages/utils/src/value.ts
+++ b/packages/utils/src/value.ts
@@ -94,7 +94,11 @@ export function addAssets(...assets: Assets[]): Assets {
   return assets.reduce((a, b) => {
     for (const k in b) {
       if (Object.hasOwn(b, k)) {
-        a[k] = (a[k] || 0n) + b[k];
+        if ((a[k] || 0n) + b[k] === 0n) {
+          delete a[k];
+        } else {
+          a[k] = (a[k] || 0n) + b[k];
+        }
       }
     }
     return a;


### PR DESCRIPTION
This PR implements a fix to `addAssets` so that the assets which their quantities sum to zero get removed.