### PR TITLE
fix: ensure lovelace amounts use BigInt type

### DIFF
--- a/.changeset/cold-frogs-listen.md
+++ b/.changeset/cold-frogs-listen.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/utils": patch
+---
+
+ensure lovelace amounts use BigInt type

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
   push:

--- a/packages/utils/src/value.ts
+++ b/packages/utils/src/value.ts
@@ -29,7 +29,7 @@ export function valueToAssets(value: CML.Value): Assets {
 
 export function assetsToValue(assets: Assets): CML.Value {
   const multiAsset = CML.MultiAsset.new();
-  const lovelace = assets["lovelace"] ? assets["lovelace"] : 0n;
+  const lovelace = assets["lovelace"] ? BigInt(assets["lovelace"]) : 0n;
   const units = Object.keys(assets);
   const policies = Array.from(
     new Set(


### PR DESCRIPTION
As we are reading the reference utxos from a json file, the type is Number and not BigInt for the lovelace amount, which causes a conversion issue by calling `return CML.Value.new(lovelace, multiAsset);` at the end of this function, as lovelace doesn't match the BigInt type expected by the `CML`.