### PR TITLE
fix/koios: Set CBOR content-type header for Koios submitTx

### DIFF
--- a/.changeset/stale-hornets-type.md
+++ b/.changeset/stale-hornets-type.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/provider": patch
+---
+
+fix koios submit tx

--- a/packages/provider/src/internal/koios.ts
+++ b/packages/provider/src/internal/koios.ts
@@ -280,7 +280,10 @@ export const postWithSchemaValidation = <A, I, R>(
     Effect.flatMap((req) =>
       headers["Content-Type"] === "application/cbor"
         ? Effect.succeed(
-            HttpClientRequest.uint8ArrayBody(data as Uint8Array, headers['Content-Type'])(req),
+            HttpClientRequest.uint8ArrayBody(
+              data as Uint8Array,
+              headers["Content-Type"],
+            )(req),
           )
         : HttpClientRequest.jsonBody(data)(req),
     ),

--- a/packages/provider/src/internal/koios.ts
+++ b/packages/provider/src/internal/koios.ts
@@ -1,17 +1,16 @@
 import {
+  HttpBody,
   HttpClient,
   HttpClientRequest,
   HttpClientResponse,
 } from "@effect/platform";
 import { HttpBodyError } from "@effect/platform/HttpBody";
 import { HttpClientError } from "@effect/platform/HttpClientError";
-import { ArrayFormatter } from "@effect/schema";
 import * as S from "@effect/schema/Schema";
 import { Effect, pipe } from "effect";
 import * as CoreType from "@lucid-evolution/core-types";
 import { ParseError } from "@effect/schema/ParseResult";
 import { applyDoubleCborEncoding } from "@lucid-evolution/utils";
-import { TimeoutException } from "effect/Cause";
 
 export const ProtocolParametersSchema = S.Struct({
   pvt_motion_no_confidence: S.Number,
@@ -273,10 +272,17 @@ export const postWithSchemaValidation = <A, I, R>(
   url: string | URL,
   data: unknown,
   schema: S.Schema<A, I, R>,
+  headers?: Record<string, string>,
 ): Effect.Effect<A, HttpClientError | HttpBodyError | ParseError, R> =>
   pipe(
     HttpClientRequest.post(url),
     HttpClientRequest.jsonBody(data),
+    Effect.map((req: HttpClientRequest.HttpClientRequest) => {
+      if (headers) {
+        return HttpClientRequest.setHeaders(headers)(req);
+      }
+      return req;
+    }),
     Effect.flatMap(HttpClient.fetch),
     HttpClientResponse.json,
     Effect.flatMap(S.decodeUnknown(schema)),

--- a/packages/provider/src/koios.ts
+++ b/packages/provider/src/koios.ts
@@ -271,7 +271,9 @@ export class Koios implements Provider {
     const body = fromHex(tx);
     const schema = _Koios.TxHashSchema;
     const result = await pipe(
-      _Koios.postWithSchemaValidation(url, body, schema),
+      _Koios.postWithSchemaValidation(url, body, schema, {
+				'Content-Type': 'application/cbor',
+			}),
       Effect.timeout(10_000),
       Effect.catchAllCause((cause) => new KoiosError({ cause })),
       Effect.runPromise,

--- a/packages/provider/src/koios.ts
+++ b/packages/provider/src/koios.ts
@@ -272,8 +272,8 @@ export class Koios implements Provider {
     const schema = _Koios.TxHashSchema;
     const result = await pipe(
       _Koios.postWithSchemaValidation(url, body, schema, {
-				'Content-Type': 'application/cbor',
-			}),
+        "Content-Type": "application/cbor",
+      }),
       Effect.timeout(10_000),
       Effect.catchAllCause((cause) => new KoiosError({ cause })),
       Effect.runPromise,

--- a/packages/provider/test/koios.test.ts
+++ b/packages/provider/test/koios.test.ts
@@ -1,7 +1,8 @@
 import { Koios } from "../src/koios.js";
 import { ProtocolParameters, UTxO } from "@lucid-evolution/core-types";
-import { assert, describe, expect, test } from "vitest";
+import { assert, describe, expect, test, vi } from "vitest";
 import * as PreprodConstants from "./preprod-constants.js";
+import * as _Koios from "../src/internal/koios.js";
 
 //TODO: improve test assetion
 describe.sequential("Koios", () => {
@@ -70,7 +71,46 @@ describe.sequential("Koios", () => {
   test("submitTxBadRequest", async () => {
     await expect(() => koios.submitTx("80")).rejects.toThrowError();
   });
+  test("submitTx sends correct CBOR headers", async () => {
+    const mockTransaction = PreprodConstants.evalSample1.transaction;
+    const expectedTxHash =
+      "e84eb47208757db8ed101c2114ca8953527b4a6aae51bacf17e991e5c734fec6";
 
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      headers: new Headers({
+        "content-type": "application/json",
+      }),
+      text: () => Promise.resolve(JSON.stringify(expectedTxHash)),
+      json: () => Promise.resolve(expectedTxHash),
+      body: null,
+    } as Response);
+
+    const koios = new Koios("https://preprod.koios.rest/api/v1");
+    expect(await koios.submitTx(mockTransaction)).toBe(expectedTxHash);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        href: "https://preprod.koios.rest/api/v1/submittx",
+      }),
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          get: expect.any(Function),
+        }),
+        body: expect.any(Uint8Array),
+      }),
+    );
+    const [, options] = fetchSpy.mock.calls[0];
+    const headers = options?.headers as Headers;
+    expect(headers.get("content-type")).toBe("application/cbor");
+    expect(options?.body).toBeInstanceOf(Uint8Array);
+
+    vi.restoreAllMocks();
+  });
   test("evaluates additonal utxos - sample 1", async () => {
     const redeemers = await koios.evaluateTx(
       PreprodConstants.evalSample1.transaction,


### PR DESCRIPTION
fixes https://github.com/Anastasia-Labs/lucid-evolution/issues/434

## Proposed Changes

Based on [Koios API docs](https://preprod.koios.rest/#post-/submittx), when we submit a transaction, headers must be:
```
content-type: application/cbor
```
Currently we pass `application/json` which makes the request to fail with the following error:
```
(FiberFailure) KoiosError: ParseError: Expected string, actual null
```
This PR updates the Koios provider implementation to properly handle CBOR-encoded transaction submissions:

* Added support for custom headers in `postWithSchemaValidation`
* Set correct `Content-Type: application/cbor` header for transaction submissions
* Added comprehensive test coverage for header handling
* Removed unused imports for cleaner codebase

## Implementation Details
During the implementation we made the following changes:
* Modified `postWithSchemaValidation` to accept an optional headers parameter
* Updated the Koios provider to set CBOR content type when submitting transactions
* Added test mocks to verify header handling
* Simplified the codebase by removing unnecessary dependencies

## Testing Instructions
* Run the full test suite to verify all existing functionality remains intact
* Try submitting transactions through the Koios provider to verify proper submission
* Verify that the new test case for CBOR headers passes
* Check that transactions are properly accepted by the Koios API with the new headers
