### PR TITLE
Add: Koios token support

### DIFF
--- a/.changeset/six-readers-guess.md
+++ b/.changeset/six-readers-guess.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/provider": patch
+---
+
+Add token support to Koios provider

--- a/packages/provider/test/koios.test.ts
+++ b/packages/provider/test/koios.test.ts
@@ -165,10 +165,6 @@ describe.sequential("Koios", () => {
       vi.restoreAllMocks();
       koiosWithToken = new Koios(BASE_URL, MOCK_TOKEN);
     });
-    beforeEach(() => {
-      vi.restoreAllMocks();
-      koiosWithToken = new Koios(BASE_URL, MOCK_TOKEN);
-    });
 
     test("getHeadersWithToken utility function", () => {
       // Test with token

--- a/packages/provider/test/koios.test.ts
+++ b/packages/provider/test/koios.test.ts
@@ -349,7 +349,9 @@ describe.sequential("Koios", () => {
         body: null,
       } as Response);
 
-      expect(await koiosWithToken.submitTx(mockTransaction)).toBe(expectedTxHash);
+      expect(await koiosWithToken.submitTx(mockTransaction)).toBe(
+        expectedTxHash,
+      );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       const [url, options] = fetchSpy.mock.calls[0];

--- a/packages/provider/test/koios.test.ts
+++ b/packages/provider/test/koios.test.ts
@@ -278,7 +278,7 @@ describe.sequential("Koios", () => {
           }) as Response,
       );
 
-			await koiosWithToken.getProtocolParameters();
+      await koiosWithToken.getProtocolParameters();
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       const [url, options] = fetchSpy.mock.calls[0];


### PR DESCRIPTION
Fixes https://github.com/Anastasia-Labs/lucid-evolution/issues/439

## Add token support to Koios provider
**Proposed Changes**

Based on the [Koios API specs](https://api.koios.rest/#overview--authentication), Koios can take in the request, an optional *auth token*. This PR aims to add token support to the Koios provider implementation:

- Added support for authorization tokens in request headers
- Updated the internal methods to properly pass token through the request chain
- Added test coverage for token handling
- Maintained backward compatibility for non-authenticated requests

### Implementation Details
During the implementation we made the following changes:

- Added optional token parameter to Koios constructor
- Created `getHeadersWithToken` utility to handle token header construction
- Updated internal HTTP methods to accept and forward headers
- Added test coverage for both token and non-token scenarios

### Testing Instructions

- Run the full test suite to verify all existing functionality remains intact
- Try making authenticated requests through the Koios provider
- Verify that the new test cases for token handling pass
- Check that both authenticated and non-authenticated requests work as expected