### PR TITLE
Fix `unixTimeToSlot` for Custom network

### DIFF
--- a/.changeset/wise-queens-leave.md
+++ b/.changeset/wise-queens-leave.md
@@ -1,0 +1,6 @@
+---
+"@lucid-evolution/lucid": patch
+"@lucid-evolution/utils": patch
+---
+
+Fix `unixTimeToSlot` for Custom network

--- a/packages/lucid/src/lucid-evolution/LucidEvolution.ts
+++ b/packages/lucid/src/lucid-evolution/LucidEvolution.ts
@@ -9,6 +9,7 @@ import {
   Transaction,
   TxHash,
   Unit,
+  UnixTime,
   UTxO,
   Wallet,
   WalletApi,
@@ -56,6 +57,7 @@ export type LucidEvolution = {
     fromAddress: (address: string, utxos: UTxO[]) => void;
   };
   currentSlot: () => number;
+  unixTimeToSlot: (unixTime: UnixTime) => number;
   utxosAt: (addressOrCredential: string | Credential) => Promise<UTxO[]>;
   utxosAtWithUnit: (
     addressOrCredential: string | Credential,
@@ -223,6 +225,12 @@ export const Lucid = async (
         Effect.map((network) => unixTimeToSlot(network, Date.now())),
         Effect.runSync,
       ),
+    unixTimeToSlot: (unixTime: UnixTime) =>
+    pipe(
+      validateNotNullableNetwork(config.network),
+      Effect.map((network) => unixTimeToSlot(network, unixTime)),
+      Effect.runSync,
+    ),
     utxosAt: (addressOrCredential: string | Credential) =>
       pipe(
         validateNotNullableProvider(config.provider),

--- a/packages/lucid/src/lucid-evolution/LucidEvolution.ts
+++ b/packages/lucid/src/lucid-evolution/LucidEvolution.ts
@@ -226,11 +226,11 @@ export const Lucid = async (
         Effect.runSync,
       ),
     unixTimeToSlot: (unixTime: UnixTime) =>
-    pipe(
-      validateNotNullableNetwork(config.network),
-      Effect.map((network) => unixTimeToSlot(network, unixTime)),
-      Effect.runSync,
-    ),
+      pipe(
+        validateNotNullableNetwork(config.network),
+        Effect.map((network) => unixTimeToSlot(network, unixTime)),
+        Effect.runSync,
+      ),
     utxosAt: (addressOrCredential: string | Credential) =>
       pipe(
         validateNotNullableProvider(config.provider),

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -6,12 +6,12 @@ import {
 } from "@lucid-evolution/plutus";
 
 /**
- * Converts unix time to slot based on the network. For "Custom" network 
+ * Converts unix time to slot based on the network. For "Custom" network
  * it is advisable use `unixTimeToSlot` method from `LucidEvolution`
  * instance to avoid uninitialized `SLOT_CONFIG_NETWORK` issue. More details
  * on the issue can be found here https://github.com/Anastasia-Labs/lucid-evolution/pull/443
- * @param network 
- * @param unixTime 
+ * @param network
+ * @param unixTime
  * @returns Slot
  */
 export function unixTimeToSlot(network: Network, unixTime: UnixTime): Slot {

--- a/packages/utils/src/time.ts
+++ b/packages/utils/src/time.ts
@@ -5,6 +5,15 @@ import {
   unixTimeToEnclosingSlot,
 } from "@lucid-evolution/plutus";
 
+/**
+ * Converts unix time to slot based on the network. For "Custom" network 
+ * it is advisable use `unixTimeToSlot` method from `LucidEvolution`
+ * instance to avoid uninitialized `SLOT_CONFIG_NETWORK` issue. More details
+ * on the issue can be found here https://github.com/Anastasia-Labs/lucid-evolution/pull/443
+ * @param network 
+ * @param unixTime 
+ * @returns Slot
+ */
 export function unixTimeToSlot(network: Network, unixTime: UnixTime): Slot {
   return unixTimeToEnclosingSlot(unixTime, SLOT_CONFIG_NETWORK[network]);
 }


### PR DESCRIPTION
fix: add `unixTimeToSlot` method to `LucidEvolution` to fix incorrect slot derived from `unixTimeToSlot` util

console.log output:

```
app-1  | consensusState.timestamp 1733758963077000000n
app-1  | validToTime 1733759083077
app-1  | validToSlot Infinity
app-1  | currentSlot 2201
app-1  | this.lucidService.lucid.config().network Custom
app-1  | currentSlotTest Infinity
```
And this is the code snippet in our gateway:

```ts
const validToTime = Number(consensusState.timestamp / 10n ** 6n + 120n * 10n ** 3n);
const validToSlot = unixTimeToSlot(this.lucidService.lucid.config().network, Number(validToTime));
const currentSlot = this.lucidService.lucid.currentSlot();

console.log('consensusState.timestamp', consensusState.timestamp);
console.log('validToTime', validToTime);
console.log('validToSlot', validToSlot);
console.log('currentSlot', currentSlot);
console.log('this.lucidService.lucid.config().network', this.lucidService.lucid.config().network);
console.log('currentSlotTest', unixTimeToSlot(this.lucidService.lucid.config().network, Date.now()));
```

The strange thing is that this.lucidService.lucid.currentSlot() seems to be correct, while unixTimeToSlot(this.lucidService.lucid.config().network, Date.now()) seems to be off, but if I look into the codebase of lucid evolution currentSlot() does the same thing

This is how lucid has been configured
```ts
const provider = new Lucid.Kupmios(configService.get('kupoEndpoint'), configService.get('ogmiosEndpoint'));
const lucid = await Lucid.Lucid(provider, 'Custom');
const chainZeroTime = await querySystemStart(configService.get('ogmiosEndpoint'));
Lucid.SLOT_CONFIG_NETWORK.Custom.zeroTime = chainZeroTime;
Lucid.SLOT_CONFIG_NETWORK.Custom.slotLength = 1000;
```

The issue seems to stem from updated `SLOT_CONFIG_NETWORK` not being available to `unixTimeToSlot` whereas it is for `currentSlot`. This PR adds a method named `unixTimeToSlot` to `LucidEvolution` type so configurable slot config for "Custom" type is available.