### PR TITLE
fix: datumHash

### DIFF
--- a/.changeset/large-pans-promise.md
+++ b/.changeset/large-pans-promise.md
@@ -1,0 +1,7 @@
+---
+"@lucid-evolution/lucid": patch
+"@lucid-evolution/utils": patch
+---
+
+UTXO handling to normalize entries containing both a `datum` and `datumHash`.
+The `datum` field is now removed when a `datumHash` is present to ensure consistency and avoid errors during transaction evaluation.

--- a/packages/lucid/src/tx-builder/internal/Read.ts
+++ b/packages/lucid/src/tx-builder/internal/Read.ts
@@ -3,28 +3,33 @@ import { Data } from "@lucid-evolution/plutus";
 import { utxoToCore } from "@lucid-evolution/utils";
 import { UTxO } from "@lucid-evolution/core-types";
 import * as TxBuilder from "../TxBuilder.js";
-import { datumOf } from "../../lucid-evolution/utils.js";
 import { ERROR_MESSAGE, TxBuilderError } from "../../Errors.js";
 
 export const readError = (cause: unknown) =>
   new TxBuilderError({ cause: `{ Read : ${cause} }` });
 
-export const readFrom = (
-  config: TxBuilder.TxBuilderConfig,
-  utxos: UTxO[],
-): Effect.Effect<void, TxBuilderError> =>
+export const readFrom = (config: TxBuilder.TxBuilderConfig, utxos: UTxO[]) =>
   Effect.gen(function* () {
     if (utxos.length === 0) yield* readError(ERROR_MESSAGE.EMPTY_UTXO);
-    for (const utxo of utxos) {
-      if (utxo.datumHash) {
-        const data = yield* Effect.tryPromise({
-          try: () => datumOf(config.lucidConfig.provider, utxo),
-          catch: (cause) => readError(cause),
-        });
+    for (const { datumHash, datum, ...rest } of utxos) {
+      // This UTXO value is intended solely for internal use.
+      // When the UTXO contains a datumHash but no datum, the datum must be fetched and included.
+      // This ensures the txBuilder can later add the datum into the Plutus data transaction witness field.
+      // Additionally, when evaluating a transaction, the datum field must be removed if the datumHash has a value.
+      const resolvedDatum =
+        datumHash && !datum
+          ? yield* pipe(
+              Effect.promise(() =>
+                config.lucidConfig.provider.getDatum(datumHash),
+              ),
+              Effect.map(Data.to),
+            )
+          : datum;
 
-        utxo.datum = Data.to(data);
-      }
+      const utxo: UTxO = { ...rest, datumHash, datum: resolvedDatum };
+
       const coreUtxo = utxoToCore(utxo);
+
       // An array of unspent transaction outputs to be used as inputs when running uplc eval.
       config.readInputs.push(utxo);
       config.txBuilder.add_reference_input(coreUtxo);

--- a/packages/utils/src/utxo.ts
+++ b/packages/utils/src/utxo.ts
@@ -279,12 +279,12 @@ const buildDatum = (
   utxo: UTxO,
   builder: CML.TransactionOutputBuilder,
 ): CML.TransactionOutputBuilder => {
-  //TODO: test with DatumHash
-  if (utxo.datumHash)
-    return builder.with_data(
-      CML.DatumOption.new_hash(CML.DatumHash.from_hex(utxo.datumHash)),
+  // with DatumHash
+  if (utxo.datumHash && utxo.datum)
+    return builder.with_communication_data(
+      CML.PlutusData.from_cbor_hex(utxo.datum),
     );
-  // inline datum
+  // with InlineDatum
   if (utxo.datum)
     return builder.with_data(
       CML.DatumOption.new_datum(CML.PlutusData.from_cbor_hex(utxo.datum)),

--- a/packages/utils/test/utxo.test.ts
+++ b/packages/utils/test/utxo.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "vitest";
 import * as CML from "@anastasia-labs/cardano-multiplatform-lib-nodejs";
-import { coreToUtxo } from "../src/index.js";
+import { coreToUtxo, utxoToCore } from "../src/index.js";
 import { UTxO } from "@lucid-evolution/core-types";
 
 it("should deserialize CBOR UTXO data from the first sample", () => {
@@ -37,4 +37,28 @@ it("should deserialize CBOR UTXO data from the second sample", () => {
     scriptRef: undefined,
   };
   expect(coreToUtxo(cmlUTXO)).toStrictEqual(utxo);
+});
+
+it("should deserialize to utxo withn datumHash", () => {
+  const utxo: UTxO = {
+    txHash: "f061f4e8490472008182fc922e8ecd414f2fa5005ea218202bd324fbe8746919",
+    outputIndex: 0,
+    address: "addr_test1wqn7wnkhny2j475ac709vg3kw6wf59f3hdl3htfpwg8xmtqtxyz6a",
+    assets: { lovelace: 10000000n },
+    datumHash:
+      "48300c087b5dbc6198ed7cfbd5c04028360e0d9270eec318addbae8b6305a909",
+    datum:
+      "d8799f581c9fc430ea1f3adc20eebb813b2649e85c934ea5bc13d7b7fbe2b24e50ff",
+    scriptRef: undefined,
+  };
+  expect(coreToUtxo(utxoToCore(utxo))).toStrictEqual({
+    txHash: "f061f4e8490472008182fc922e8ecd414f2fa5005ea218202bd324fbe8746919",
+    outputIndex: 0,
+    assets: { lovelace: 10000000n },
+    address: "addr_test1wqn7wnkhny2j475ac709vg3kw6wf59f3hdl3htfpwg8xmtqtxyz6a",
+    datumHash:
+      "48300c087b5dbc6198ed7cfbd5c04028360e0d9270eec318addbae8b6305a909",
+    datum: undefined,
+    scriptRef: undefined,
+  });
 });


### PR DESCRIPTION
## Description

```
UTXO handling to normalize entries containing both a `datum` and `datumHash`.
The `datum` field is now removed when a `datumHash` is present to ensure consistency and avoid errors during transaction evaluation.
```
Fixes https://github.com/Anastasia-Labs/lucid-evolution/issues/454

## Type of change

- [x] 🔧 Bug fix

If the feature is substantial or introduces breaking changes without a discussion, its best to open an [issue](https://github.com/Anastasia-Labs/lucid-evolution/issues) first.

## Checklist

- [x] I commented my code
- [x] Added/modified unit tests
- [x] I made corresponding changes to the documentation

## Additional Notes

