### PR TITLE
feat: Add TransactionInput, TransactionHash (Experimental)

### DIFF
--- a/.changeset/swift-jokes-cough.md
+++ b/.changeset/swift-jokes-cough.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/experimental": patch
+---
+
+Add TransactionInput and TransactionHash CML equivalent types to experimental

--- a/packages/experimental/docgen.json
+++ b/packages/experimental/docgen.json
@@ -5,7 +5,7 @@
     "src/**/index.ts",
     "src/CardanoJS/**/*.ts",
     "src/old/**/*.ts",
-    "src/!(Data|TSchema|Address|AddressDetails|AddressTag|BaseAddress|Bech32|ByronAddress|EnterpriseAddress|Header|PaymentAddress|PointerAddress|Pointer|Credential|KeyHash|ScriptHash).ts"
+    "src/!(Data|TSchema|Address|AddressDetails|AddressTag|BaseAddress|Bech32|ByronAddress|EnterpriseAddress|Header|PaymentAddress|PointerAddress|Pointer|Credential|KeyHash|ScriptHash|TransactionHash|TransactionInput).ts"
   ],
   "enforceDescriptions": false,
   "enforceExamples": false,

--- a/packages/experimental/docs/modules/Address.ts.md
+++ b/packages/experimental/docs/modules/Address.ts.md
@@ -39,8 +39,8 @@ This decodes the address format according to CIP-0019 specification
 ```ts
 export declare const fromBech32: SerdeImpl.FromBech32<
   Address,
-  | ScriptHash.ScriptHashError
   | Bytes.BytesError
+  | ScriptHash.ScriptHashError
   | KeyHash.KeyHashError
   | PointerAddress.PointerAddressError
   | ParseError
@@ -81,8 +81,8 @@ Convert bytes to an address structure
 ```ts
 export declare const fromBytes: SerdeImpl.FromBytes<
   Address,
-  | ScriptHash.ScriptHashError
   | Bytes.BytesError
+  | ScriptHash.ScriptHashError
   | KeyHash.KeyHashError
   | PointerAddress.PointerAddressError
   | ParseError

--- a/packages/experimental/docs/modules/AddressDetails.ts.md
+++ b/packages/experimental/docs/modules/AddressDetails.ts.md
@@ -30,8 +30,8 @@ Extract detailed information from a bech32 address
 ```ts
 export declare const fromBech32: SerdeImpl.FromBech32<
   AddressDetails,
-  | ScriptHash.ScriptHashError
   | Bytes.BytesError
+  | ScriptHash.ScriptHashError
   | KeyHash.KeyHashError
   | PointerAddress.PointerAddressError
   | ParseError
@@ -71,8 +71,8 @@ Extract detailed information from a hex-encoded address
 ```ts
 export declare const fromHex: SerdeImpl.FromHex<
   AddressDetails,
-  | ScriptHash.ScriptHashError
   | Bytes.BytesError
+  | ScriptHash.ScriptHashError
   | KeyHash.KeyHashError
   | PointerAddress.PointerAddressError
   | ParseError
@@ -117,8 +117,8 @@ export declare const fromString: (
     YieldWrap<
       Effect.Effect<
         AddressDetails,
-        | ScriptHash.ScriptHashError
         | Bytes.BytesError
+        | ScriptHash.ScriptHashError
         | KeyHash.KeyHashError
         | PointerAddress.PointerAddressError
         | ParseError
@@ -133,8 +133,8 @@ export declare const fromString: (
           YieldWrap<
             Effect.Effect<
               AddressDetails,
-              | ScriptHash.ScriptHashError
               | Bytes.BytesError
+              | ScriptHash.ScriptHashError
               | KeyHash.KeyHashError
               | PointerAddress.PointerAddressError
               | ParseError
@@ -150,8 +150,8 @@ export declare const fromString: (
     YieldWrap<
       Effect.Effect<
         AddressDetails,
-        | ScriptHash.ScriptHashError
         | Bytes.BytesError
+        | ScriptHash.ScriptHashError
         | KeyHash.KeyHashError
         | PointerAddress.PointerAddressError
         | ParseError
@@ -166,8 +166,8 @@ export declare const fromString: (
           YieldWrap<
             Effect.Effect<
               AddressDetails,
-              | ScriptHash.ScriptHashError
               | Bytes.BytesError
+              | ScriptHash.ScriptHashError
               | KeyHash.KeyHashError
               | PointerAddress.PointerAddressError
               | ParseError

--- a/packages/experimental/docs/modules/Credential.ts.md
+++ b/packages/experimental/docs/modules/Credential.ts.md
@@ -43,8 +43,8 @@ Decode a CBOR hex string to a Credential
 export declare const fromCBOR: SerdeImpl.FromCBOR<
   ScriptHash.ScriptHash | KeyHash.KeyHash,
   | CBOR.CBORError
-  | ScriptHash.ScriptHashError
   | Bytes.BytesError
+  | ScriptHash.ScriptHashError
   | KeyHash.KeyHashError
   | CredentialError
 >;

--- a/packages/experimental/docs/modules/Data.ts.md
+++ b/packages/experimental/docs/modules/Data.ts.md
@@ -725,9 +725,9 @@ export declare const isConstr: (
   u: unknown,
   overrideOptions?: SchemaAST.ParseOptions | number,
 ) => u is {
+  readonly index: bigint;
   readonly fields: readonly Data[];
   readonly _tag: "Constr";
-  readonly index: bigint;
 };
 ```
 
@@ -1094,9 +1094,9 @@ export declare const decodeCBOR: <Source, Target extends Data>(
       readonly entries: readonly { readonly k: Data; readonly v: Data }[];
     }
   | {
+      readonly index: bigint;
       readonly fields: readonly Data[];
       readonly _tag: "Constr";
-      readonly index: bigint;
     }
   | Source,
   [
@@ -1113,9 +1113,9 @@ export declare const decodeCBOR: <Source, Target extends Data>(
               }[];
             }
           | {
+              readonly index: bigint;
               readonly fields: readonly Data[];
               readonly _tag: "Constr";
-              readonly index: bigint;
             },
           CML.PlutusData.PlutusDataError,
           never
@@ -1138,9 +1138,9 @@ export declare const decodeCBOR: <Source, Target extends Data>(
                     }[];
                   }
                 | {
+                    readonly index: bigint;
                     readonly fields: readonly Data[];
                     readonly _tag: "Constr";
-                    readonly index: bigint;
                   },
                 CML.PlutusData.PlutusDataError,
                 never
@@ -1164,9 +1164,9 @@ export declare const decodeCBOR: <Source, Target extends Data>(
               }[];
             }
           | {
+              readonly index: bigint;
               readonly fields: readonly Data[];
               readonly _tag: "Constr";
-              readonly index: bigint;
             },
           CML.PlutusData.PlutusDataError,
           never
@@ -1189,9 +1189,9 @@ export declare const decodeCBOR: <Source, Target extends Data>(
                     }[];
                   }
                 | {
+                    readonly index: bigint;
                     readonly fields: readonly Data[];
                     readonly _tag: "Constr";
-                    readonly index: bigint;
                   },
                 CML.PlutusData.PlutusDataError,
                 never
@@ -1304,9 +1304,9 @@ export declare const resolveCBOR: (input: string) => Effect.Effect<
       readonly entries: readonly { readonly k: Data; readonly v: Data }[];
     }
   | {
+      readonly index: bigint;
       readonly fields: readonly Data[];
       readonly _tag: "Constr";
-      readonly index: bigint;
     },
   [
     YieldWrap<Effect.Effect<PlutusData, CML.PlutusData.PlutusDataError, never>>,

--- a/packages/experimental/docs/modules/ScriptHash.ts.md
+++ b/packages/experimental/docs/modules/ScriptHash.ts.md
@@ -193,7 +193,7 @@ Create a ScriptHash from a CBOR hex string.
 ```ts
 export declare const fromCBOR: SerdeImpl.FromCBOR<
   ScriptHash,
-  CBOR.CBORError | ScriptHashError | Bytes.BytesError
+  CBOR.CBORError | Bytes.BytesError | ScriptHashError
 >;
 ```
 

--- a/packages/experimental/docs/modules/TSchema.ts.md
+++ b/packages/experimental/docs/modules/TSchema.ts.md
@@ -1,6 +1,6 @@
 ---
 title: TSchema.ts
-nav_order: 303
+nav_order: 305
 parent: Modules
 ---
 

--- a/packages/experimental/docs/modules/TransactionHash.ts.md
+++ b/packages/experimental/docs/modules/TransactionHash.ts.md
@@ -1,0 +1,528 @@
+---
+title: TransactionHash.ts
+nav_order: 303
+parent: Modules
+---
+
+## TransactionHash overview
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [constants](#constants)
+  - [TRANSACTIONHASH_BYTES_LENGTH](#transactionhash_bytes_length)
+  - [TRANSACTIONHASH_HEX_LENGTH](#transactionhash_hex_length)
+- [constructors](#constructors)
+  - [fromBytes](#frombytes)
+  - [fromBytesOrThrow](#frombytesorthrow)
+  - [make](#make)
+  - [makeOrThrow](#makeorthrow)
+- [encoding/decoding](#encodingdecoding)
+  - [fromCBOR](#fromcbor)
+  - [fromCBORBytes](#fromcborbytes)
+  - [fromCBORBytesOrThrow](#fromcborbytesorthrow)
+  - [fromCBOROrThrow](#fromcbororthrow)
+  - [toCBOR](#tocbor)
+  - [toCBORBytes](#tocborbytes)
+- [equality](#equality)
+  - [equals](#equals)
+- [errors](#errors)
+  - [TransactionHashError (class)](#transactionhasherror-class)
+- [generators](#generators)
+  - [generator](#generator)
+- [schemas](#schemas)
+  - [TransactionHash (class)](#transactionhash-class)
+    - [[Inspectable.NodeInspectSymbol] (method)](#inspectablenodeinspectsymbol-method)
+- [transformation](#transformation)
+  - [toBytes](#tobytes)
+- [utils](#utils)
+  - [TransactionHash (interface)](#transactionhash-interface)
+
+---
+
+# constants
+
+## TRANSACTIONHASH_BYTES_LENGTH
+
+The length in bytes of a TransactionHash.
+
+**Signature**
+
+```ts
+export declare const TRANSACTIONHASH_BYTES_LENGTH: 32;
+```
+
+Added in v2.0.0
+
+## TRANSACTIONHASH_HEX_LENGTH
+
+The length in hex characters of a TransactionHash.
+
+**Signature**
+
+```ts
+export declare const TRANSACTIONHASH_HEX_LENGTH: 64;
+```
+
+Added in v2.0.0
+
+# constructors
+
+## fromBytes
+
+Create a TransactionHash directly from bytes.
+
+**Signature**
+
+```ts
+export declare const fromBytes: SerdeImpl.FromBytes<
+  TransactionHash,
+  TransactionHashError
+>;
+```
+
+**Example**
+
+```ts
+import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+import { Effect } from "effect";
+import assert from "assert";
+
+const bytes = Bytes.fromHexOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionHashEffect = TransactionHash.fromBytes(bytes);
+const transactionHash = Effect.runSync(transactionHashEffect);
+assert(transactionHash._tag === "TransactionHash");
+assert(
+  transactionHash.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+```
+
+Added in v2.0.0
+
+## fromBytesOrThrow
+
+Create a TransactionHash directly from bytes, throws on error.
+
+**Signature**
+
+```ts
+export declare const fromBytesOrThrow: (bytes: Uint8Array) => TransactionHash;
+```
+
+**Example**
+
+```ts
+import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const bytes = Bytes.fromHexOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionHash = TransactionHash.fromBytesOrThrow(bytes);
+assert(transactionHash._tag === "TransactionHash");
+assert(
+  transactionHash.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+```
+
+Added in v2.0.0
+
+## make
+
+Construct a TransactionHash from a hex string.
+
+**Signature**
+
+```ts
+export declare const make: SerdeImpl.Make<
+  TransactionHash,
+  TransactionHashError
+>;
+```
+
+**Example**
+
+```ts
+import { TransactionHash } from "@lucid-evolution/experimental";
+import { Effect } from "effect";
+import assert from "assert";
+
+const hash = "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
+const transactionHashEffect = TransactionHash.make(hash);
+const transactionHash = Effect.runSync(transactionHashEffect);
+assert(transactionHash._tag === "TransactionHash");
+assert(transactionHash.hash === hash);
+```
+
+Added in v2.0.0
+
+## makeOrThrow
+
+Construct a TransactionHash from a hex string, throws on error.
+
+**Signature**
+
+```ts
+export declare const makeOrThrow: SerdeImpl.MakeOrThrow<TransactionHash>;
+```
+
+**Example**
+
+```ts
+import { TransactionHash } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const hash = "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
+const transactionHash = TransactionHash.makeOrThrow(hash);
+assert(transactionHash._tag === "TransactionHash");
+assert(transactionHash.hash === hash);
+```
+
+Added in v2.0.0
+
+# encoding/decoding
+
+## fromCBOR
+
+Create a TransactionHash from a CBOR hex string.
+
+**Signature**
+
+```ts
+export declare const fromCBOR: SerdeImpl.FromCBOR<
+  TransactionHash,
+  CBOR.CBORError | TransactionHashError | Bytes.BytesError
+>;
+```
+
+**Example**
+
+```ts
+import { TransactionHash } from "@lucid-evolution/experimental";
+import { Effect } from "effect";
+import assert from "assert";
+
+const cborHex =
+  "5820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
+const transactionHashEffect = TransactionHash.fromCBOR(cborHex);
+const transactionHash = Effect.runSync(transactionHashEffect);
+assert(transactionHash._tag === "TransactionHash");
+assert(
+  transactionHash.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+```
+
+Added in v2.0.0
+
+## fromCBORBytes
+
+Create a TransactionHash from CBOR bytes.
+
+**Signature**
+
+```ts
+export declare const fromCBORBytes: SerdeImpl.FromCBORBytes<
+  TransactionHash,
+  CBOR.CBORError | TransactionHashError
+>;
+```
+
+**Example**
+
+```ts
+import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+import { Effect } from "effect";
+import assert from "assert";
+
+const bytes = Bytes.fromHexOrThrow(
+  "5820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionHashEffect = TransactionHash.fromCBORBytes(bytes);
+const transactionHash = Effect.runSync(transactionHashEffect);
+assert(transactionHash._tag === "TransactionHash");
+assert(
+  transactionHash.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+```
+
+Added in v2.0.0
+
+## fromCBORBytesOrThrow
+
+Create a TransactionHash from CBOR bytes, throws on error.
+
+**Signature**
+
+```ts
+export declare const fromCBORBytesOrThrow: (
+  bytes: Uint8Array,
+) => TransactionHash;
+```
+
+**Example**
+
+```ts
+import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const bytes = Bytes.fromHexOrThrow(
+  "5820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionHash = TransactionHash.fromCBORBytesOrThrow(bytes);
+assert(transactionHash._tag === "TransactionHash");
+assert(
+  transactionHash.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+```
+
+Added in v2.0.0
+
+## fromCBOROrThrow
+
+Create a TransactionHash from a CBOR hex string, throws on error.
+
+**Signature**
+
+```ts
+export declare const fromCBOROrThrow: (cborHex: string) => TransactionHash;
+```
+
+**Example**
+
+```ts
+import { TransactionHash } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const transactionHash = TransactionHash.fromCBOROrThrow(
+  "5820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+assert(transactionHash._tag === "TransactionHash");
+assert(
+  transactionHash.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+```
+
+Added in v2.0.0
+
+## toCBOR
+
+Convert a TransactionHash to CBOR hex string.
+
+**Signature**
+
+```ts
+export declare const toCBOR: SerdeImpl.ToCBOR<TransactionHash>;
+```
+
+**Example**
+
+```ts
+import { TransactionHash } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const transactionHash = TransactionHash.makeOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const hex = TransactionHash.toCBOR(transactionHash);
+assert(hex.startsWith("5820"));
+assert(
+  hex.includes(
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+  ),
+);
+```
+
+Added in v2.0.0
+
+## toCBORBytes
+
+Convert a TransactionHash to CBOR bytes.
+
+**Signature**
+
+```ts
+export declare const toCBORBytes: SerdeImpl.ToCBORBytes<TransactionHash>;
+```
+
+**Example**
+
+```ts
+import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const transactionHash = TransactionHash.makeOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const bytes = TransactionHash.toCBORBytes(transactionHash);
+assert(bytes instanceof Uint8Array);
+```
+
+Added in v2.0.0
+
+# equality
+
+## equals
+
+Check if two TransactionHashes are equal.
+
+**Signature**
+
+```ts
+export declare const equals: (
+  a: TransactionHash,
+  b: TransactionHash,
+) => boolean;
+```
+
+**Example**
+
+```ts
+import { TransactionHash } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const hash1 = TransactionHash.makeOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const hash2 = TransactionHash.makeOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const hash3 = TransactionHash.makeOrThrow(
+  "dc97057e0949d9676e55b69f28fcb2dccb8002583a4ad761f1dbfb985f36085c",
+);
+
+assert(TransactionHash.equals(hash1, hash2) === true);
+assert(TransactionHash.equals(hash1, hash3) === false);
+```
+
+Added in v2.0.0
+
+# errors
+
+## TransactionHashError (class)
+
+Error class for TransactionHash related operations
+Extends TaggedError for better error handling and categorization
+
+**Signature**
+
+```ts
+export declare class TransactionHashError
+```
+
+**Example**
+
+```ts
+import { TransactionHash } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const error = new TransactionHash.TransactionHashError({
+  message: "Invalid transaction hash",
+});
+assert(error.message === "Invalid transaction hash");
+```
+
+Added in v2.0.0
+
+# generators
+
+## generator
+
+Generate a random TransactionHash using FastCheck.
+
+This is useful for testing purposes.
+
+**Signature**
+
+```ts
+export declare const generator: FastCheck.Arbitrary<TransactionHash>;
+```
+
+**Example**
+
+```ts
+import { TransactionHash } from "@lucid-evolution/experimental";
+import { FastCheck } from "effect";
+import assert from "assert";
+
+const randomSamples = FastCheck.sample(TransactionHash.generator, 20);
+randomSamples.forEach((transactionHash) => {
+  assert(transactionHash.hash.length === 64);
+});
+```
+
+Added in v2.0.0
+
+# schemas
+
+## TransactionHash (class)
+
+Schema for TransactionHash.
+
+**Signature**
+
+```ts
+export declare class TransactionHash
+```
+
+Added in v2.0.0
+
+### [Inspectable.NodeInspectSymbol] (method)
+
+**Signature**
+
+```ts
+[Inspectable.NodeInspectSymbol]();
+```
+
+# transformation
+
+## toBytes
+
+Convert a TransactionHash to bytes.
+
+**Signature**
+
+```ts
+export declare const toBytes: SerdeImpl.ToBytes<TransactionHash>;
+```
+
+**Example**
+
+```ts
+import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const transactionHash = TransactionHash.makeOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const bytes = TransactionHash.toBytes(transactionHash);
+assert(bytes instanceof Uint8Array);
+assert(bytes.length === 32);
+assert(
+  Bytes.toHexOrThrow(bytes) ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+```
+
+Added in v2.0.0
+
+# utils
+
+## TransactionHash (interface)
+
+**Signature**
+
+```ts
+export interface TransactionHash {
+  readonly [NominalType]: unique symbol;
+}
+```

--- a/packages/experimental/docs/modules/TransactionInput.ts.md
+++ b/packages/experimental/docs/modules/TransactionInput.ts.md
@@ -1,0 +1,401 @@
+---
+title: TransactionInput.ts
+nav_order: 304
+parent: Modules
+---
+
+## TransactionInput overview
+
+---
+
+<h2 class="text-delta">Table of contents</h2>
+
+- [constructors](#constructors)
+  - [makeOrThrow](#makeorthrow)
+- [encoding/decoding](#encodingdecoding)
+  - [fromCBOR](#fromcbor)
+  - [fromCBORBytes](#fromcborbytes)
+  - [fromCBORBytesOrThrow](#fromcborbytesorthrow)
+  - [fromCBOROrThrow](#fromcbororthrow)
+  - [toCBOR](#tocbor)
+  - [toCBORBytes](#tocborbytes)
+- [equality](#equality)
+  - [equals](#equals)
+- [model](#model)
+  - [TransactionInputError (class)](#transactioninputerror-class)
+- [predicates](#predicates)
+  - [isTransactionInput](#istransactioninput)
+- [schemas](#schemas)
+  - [TransactionInput (class)](#transactioninput-class)
+    - [[Inspectable.NodeInspectSymbol] (method)](#inspectablenodeinspectsymbol-method)
+
+---
+
+# constructors
+
+## makeOrThrow
+
+Construct a TransactionInput, throws on error.
+
+**Signature**
+
+```ts
+export declare const makeOrThrow: (
+  transactionId: TransactionHash.TransactionHash,
+  index: number,
+) => TransactionInput;
+```
+
+**Example**
+
+```ts
+import {
+  TransactionHash,
+  TransactionInput,
+} from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const transactionHash =
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
+const transactionId = TransactionHash.makeOrThrow(transactionHash);
+const transactionInput = TransactionInput.makeOrThrow(transactionId, 0);
+assert(transactionInput._tag === "TransactionInput");
+assert(transactionInput.transactionId.hash === transactionHash);
+assert(transactionInput.index === 0);
+```
+
+Added in v2.0.0
+
+# encoding/decoding
+
+## fromCBOR
+
+Decode a CBOR hex string to a TransactionInput
+
+**Signature**
+
+```ts
+export declare const fromCBOR: SerdeImpl.FromCBOR<
+  TransactionInput,
+  | CBOR.CBORError
+  | TransactionHash.TransactionHashError
+  | TransactionInputError
+  | Bytes.BytesError
+>;
+```
+
+**Example**
+
+```ts
+import { TransactionInput } from "@lucid-evolution/experimental";
+import { Effect } from "effect";
+import assert from "assert";
+
+const cborHex =
+  "82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
+const transactionInputEffect = TransactionInput.fromCBOR(cborHex);
+const transactionInput = Effect.runSync(transactionInputEffect);
+assert(
+  transactionInput.transactionId.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+assert(transactionInput.index === 0);
+```
+
+Added in v2.0.0
+
+## fromCBORBytes
+
+Decode CBOR bytes to a TransactionInput
+Internal helper function used by fromCBOR
+
+**Signature**
+
+```ts
+export declare const fromCBORBytes: SerdeImpl.FromCBORBytes<
+  TransactionInput,
+  CBOR.CBORError | TransactionHash.TransactionHashError | TransactionInputError
+>;
+```
+
+**Example**
+
+```ts
+import { TransactionInput, Bytes } from "@lucid-evolution/experimental";
+import { Effect } from "effect";
+import assert from "assert";
+
+const bytes = Bytes.fromHexOrThrow(
+  "82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionInputEffect = TransactionInput.fromCBORBytes(bytes);
+const transactionInput = Effect.runSync(transactionInputEffect);
+assert(
+  transactionInput.transactionId.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+assert(transactionInput.index === 0);
+```
+
+Added in v2.0.0
+
+## fromCBORBytesOrThrow
+
+Decode CBOR bytes to a TransactionInput, throws on error.
+
+**Signature**
+
+```ts
+export declare const fromCBORBytesOrThrow: SerdeImpl.FromCBORBytesOrThrow<TransactionInput>;
+```
+
+**Example**
+
+```ts
+import { TransactionInput, Bytes } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const bytes = Bytes.fromHexOrThrow(
+  "82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionInput = TransactionInput.fromCBORBytesOrThrow(bytes);
+assert(
+  transactionInput.transactionId.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+assert(transactionInput.index === 0);
+```
+
+Added in v2.0.0
+
+## fromCBOROrThrow
+
+Decode a CBOR hex string to a TransactionInput, throws on error.
+
+**Signature**
+
+```ts
+export declare const fromCBOROrThrow: SerdeImpl.FromCBOROrThrow<TransactionInput>;
+```
+
+**Example**
+
+```ts
+import { TransactionInput } from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const cborHex =
+  "82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
+const transactionInput = TransactionInput.fromCBOROrThrow(cborHex);
+assert(
+  transactionInput.transactionId.hash ===
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+assert(transactionInput.index === 0);
+```
+
+Added in v2.0.0
+
+## toCBOR
+
+CBOR diagnostic notation for TransactionInput:
+transactionInput = [index, transactionId]
+
+CBOR hex for TransactionInput:
+[ 0, h'cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819' ]
+
+Convert TransactionInput to CBOR hex encoding
+Uses a pre-configured CBOR encoder for better performance
+
+**Signature**
+
+```ts
+export declare const toCBOR: SerdeImpl.ToCBOR<TransactionInput>;
+```
+
+**Example**
+
+```ts
+import {
+  TransactionHash,
+  TransactionInput,
+} from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const transactionId = TransactionHash.makeOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionInput = TransactionInput.makeOrThrow(transactionId, 0);
+const cbor = TransactionInput.toCBOR(transactionInput);
+assert(
+  cbor ===
+    "82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+```
+
+Added in v2.0.0
+
+## toCBORBytes
+
+Convert TransactionInput to CBOR bytes
+Internal helper function used by toCBOR
+
+**Signature**
+
+```ts
+export declare const toCBORBytes: SerdeImpl.ToCBORBytes<TransactionInput>;
+```
+
+**Example**
+
+```ts
+import {
+  Bytes,
+  TransactionHash,
+  TransactionInput,
+} from "@lucid-evolution/experimental";
+import { Effect } from "effect";
+import assert from "assert";
+
+const transactionId = TransactionHash.makeOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionInput = TransactionInput.makeOrThrow(transactionId, 0);
+const cborBytes = TransactionInput.toCBORBytes(transactionInput);
+// Verify the bytes are correct by converting back to hex
+const hexString = Bytes.toHexOrThrow(cborBytes);
+// 82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819
+assert(hexString.startsWith("82")); // Array of 2 elements in CBOR
+assert(
+  hexString.includes(
+    "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+  ),
+);
+```
+
+Added in v2.0.0
+
+# equality
+
+## equals
+
+Check if two TransactionInput instances are equal.
+
+**Signature**
+
+```ts
+export declare const equals: (
+  a: TransactionInput,
+  b: TransactionInput,
+) => boolean;
+```
+
+**Example**
+
+```ts
+import {
+  TransactionHash,
+  TransactionInput,
+} from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const transactionId1 = TransactionHash.makeOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionId2 = TransactionHash.makeOrThrow(
+  "dddd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionInput = TransactionInput.makeOrThrow(transactionId1, 0);
+const sameTransactionInput = TransactionInput.makeOrThrow(transactionId1, 0);
+const differentTransactionInput1 = TransactionInput.makeOrThrow(
+  transactionId1,
+  1,
+);
+const differentTransactionInput2 = TransactionInput.makeOrThrow(
+  transactionId2,
+  0,
+);
+assert(
+  TransactionInput.equals(transactionInput, sameTransactionInput) === true,
+);
+assert(
+  TransactionInput.equals(transactionInput, differentTransactionInput1) ===
+    false,
+);
+assert(
+  TransactionInput.equals(transactionInput, differentTransactionInput2) ===
+    false,
+);
+```
+
+Added in v2.0.0
+
+# model
+
+## TransactionInputError (class)
+
+Error thrown when transaction input operations fail
+
+**Signature**
+
+```ts
+export declare class TransactionInputError
+```
+
+Added in v2.0.0
+
+# predicates
+
+## isTransactionInput
+
+Check if the given value is a valid TransactionInput
+
+**Signature**
+
+```ts
+export declare const isTransactionInput: (
+  u: unknown,
+  overrideOptions?: ParseOptions | number,
+) => u is TransactionInput;
+```
+
+**Example**
+
+```ts
+import {
+  TransactionHash,
+  TransactionInput,
+} from "@lucid-evolution/experimental";
+import assert from "assert";
+
+const transactionId = TransactionHash.makeOrThrow(
+  "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819",
+);
+const transactionInput = TransactionInput.makeOrThrow(transactionId, 0);
+const isValid = TransactionInput.isTransactionInput(transactionInput);
+assert(isValid === true);
+```
+
+Added in v2.0.0
+
+# schemas
+
+## TransactionInput (class)
+
+Transaction input with transaction id and index
+
+**Signature**
+
+```ts
+export declare class TransactionInput
+```
+
+Added in v2.0.0
+
+### [Inspectable.NodeInspectSymbol] (method)
+
+**Signature**
+
+```ts
+[Inspectable.NodeInspectSymbol]();
+```

--- a/packages/experimental/src/TransactionHash.ts
+++ b/packages/experimental/src/TransactionHash.ts
@@ -109,7 +109,7 @@ export const toCBORBytes: SerdeImpl.ToCBORBytes<TransactionHash> = (
  *
  * const transactionHash = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * const hex = TransactionHash.toCBOR(transactionHash);
- * assert(hex.startsWith("581c"));
+ * assert(hex.startsWith("5820"));
  * assert(hex.includes("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819"));
  *
  * @since 2.0.0
@@ -128,7 +128,7 @@ export const toCBOR: SerdeImpl.ToCBOR<TransactionHash> = (transactionHash) => {
  * import { Effect } from "effect";
  * import assert from "assert";
  *
- * const cborHex = "581cc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f";
+ * const cborHex = "5820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
  * const transactionHashEffect = TransactionHash.fromCBOR(cborHex);
  * const transactionHash = Effect.runSync(transactionHashEffect);
  * assert(transactionHash._tag === "TransactionHash");
@@ -152,7 +152,7 @@ export const fromCBOR: SerdeImpl.FromCBOR<
  * import { TransactionHash } from "@lucid-evolution/experimental";
  * import assert from "assert";
  *
- * const transactionHash = TransactionHash.fromCBOROrThrow("581cc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+ * const transactionHash = TransactionHash.fromCBOROrThrow("5820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * assert(transactionHash._tag === "TransactionHash");
  * assert(transactionHash.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  *
@@ -172,7 +172,7 @@ export const fromCBOROrThrow = (cborHex: string) => {
  * import { Effect } from "effect";
  * import assert from "assert";
  *
- * const bytes = Bytes.fromHexOrThrow("581cc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+ * const bytes = Bytes.fromHexOrThrow("5820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * const transactionHashEffect = TransactionHash.fromCBORBytes(bytes);
  * const transactionHash = Effect.runSync(transactionHashEffect);
  * assert(transactionHash._tag === "TransactionHash");
@@ -196,7 +196,7 @@ export const fromCBORBytes: SerdeImpl.FromCBORBytes<
  * import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
  * import assert from "assert";
  *
- * const bytes = Bytes.fromHexOrThrow("581cc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+ * const bytes = Bytes.fromHexOrThrow("5820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * const transactionHash = TransactionHash.fromCBORBytesOrThrow(bytes);
  * assert(transactionHash._tag === "TransactionHash");
  * assert(transactionHash.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
@@ -300,14 +300,14 @@ export const toBytes: SerdeImpl.ToBytes<TransactionHash> = (transactionHash) =>
  */
 export const make: SerdeImpl.Make<TransactionHash, TransactionHashError> =
   Effect.fnUntraced(function* (hash) {
-    if (hash.length !== TRANSACTIONHASH_HEX_LENGTH) {
-      return yield* new TransactionHashError({
-        message: `TransactionHash must be ${TRANSACTIONHASH_HEX_LENGTH} characters long.`,
-      });
-    }
     if (!Bytes.isHex(hash)) {
       return yield* new TransactionHashError({
         message: `TransactionHash must be a valid hex string.`,
+      });
+    }
+    if (hash.length !== TRANSACTIONHASH_HEX_LENGTH) {
+      return yield* new TransactionHashError({
+        message: `TransactionHash must be ${TRANSACTIONHASH_HEX_LENGTH} characters long.`,
       });
     }
     return new TransactionHash({ hash }, { disableValidation: true });

--- a/packages/experimental/src/TransactionHash.ts
+++ b/packages/experimental/src/TransactionHash.ts
@@ -1,0 +1,388 @@
+import { Effect, Schema, Data, FastCheck, Inspectable } from "effect";
+import * as CBOR from "./CBOR.js";
+import * as Bytes from "./Bytes.js";
+import { HexStringSchema } from "./Combinator.js";
+import * as SerdeImpl from "./SerdeImpl.js";
+
+/**
+ * The length in bytes of a TransactionHash.
+ *
+ * @since 2.0.0
+ * @category constants
+ */
+export const TRANSACTIONHASH_BYTES_LENGTH = 32;
+
+/**
+ * The length in hex characters of a TransactionHash.
+ *
+ * @since 2.0.0
+ * @category constants
+ */
+export const TRANSACTIONHASH_HEX_LENGTH = 64;
+
+/**
+ * Error class for TransactionHash related operations
+ * Extends TaggedError for better error handling and categorization
+ *
+ * @example
+ * import { TransactionHash } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const error = new TransactionHash.TransactionHashError({ message: "Invalid transaction hash" });
+ * assert(error.message === "Invalid transaction hash");
+ *
+ * @since 2.0.0
+ * @category errors
+ */
+export class TransactionHashError extends Data.TaggedError(
+  "TransactionHashError",
+)<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+/**
+ * Schema for validating TransactionHash hex strings with proper length.
+ *
+ * @since 2.0.0
+ * @category schemas
+ */
+const TransactionHashHexString = HexStringSchema.pipe(
+  Schema.length(TRANSACTIONHASH_HEX_LENGTH),
+).annotations({
+  message: (issue) =>
+    `must be ${TRANSACTIONHASH_HEX_LENGTH} characters, got: ${issue.actual}.`,
+});
+
+export declare const NominalType: unique symbol;
+export interface TransactionHash {
+  readonly [NominalType]: unique symbol;
+}
+
+/**
+ * Schema for TransactionHash.
+ *
+ * @since 2.0.0
+ * @category schemas
+ */
+export class TransactionHash extends Schema.TaggedClass<TransactionHash>()(
+  "TransactionHash",
+  {
+    hash: TransactionHashHexString,
+  },
+) {
+  [Inspectable.NodeInspectSymbol]() {
+    return {
+      _tag: "TransactionHash",
+      hash: this.hash,
+    };
+  }
+}
+
+/**
+ * Convert a TransactionHash to CBOR bytes.
+ *
+ * @example
+ * import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const transactionHash = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const bytes = TransactionHash.toCBORBytes(transactionHash);
+ * assert(bytes instanceof Uint8Array);
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const toCBORBytes: SerdeImpl.ToCBORBytes<TransactionHash> = (
+  transactionHash,
+) => {
+  const hashBytes = Bytes.fromHexOrThrow(transactionHash.hash);
+  return CBOR.encodeOrThrow(hashBytes);
+};
+
+/**
+ * Convert a TransactionHash to CBOR hex string.
+ *
+ * @example
+ * import { TransactionHash } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const transactionHash = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const hex = TransactionHash.toCBOR(transactionHash);
+ * assert(hex.startsWith("581c"));
+ * assert(hex.includes("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819"));
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const toCBOR: SerdeImpl.ToCBOR<TransactionHash> = (transactionHash) => {
+  const bytes = toCBORBytes(transactionHash);
+  return Bytes.toHexOrThrow(bytes);
+};
+
+/**
+ * Create a TransactionHash from a CBOR hex string.
+ *
+ * @example
+ * import { TransactionHash } from "@lucid-evolution/experimental";
+ * import { Effect } from "effect";
+ * import assert from "assert";
+ *
+ * const cborHex = "581cc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f";
+ * const transactionHashEffect = TransactionHash.fromCBOR(cborHex);
+ * const transactionHash = Effect.runSync(transactionHashEffect);
+ * assert(transactionHash._tag === "TransactionHash");
+ * assert(transactionHash.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const fromCBOR: SerdeImpl.FromCBOR<
+  TransactionHash,
+  CBOR.CBORError | Bytes.BytesError | TransactionHashError
+> = Effect.fn(function* (cborHex) {
+  const transactionHash = yield* CBOR.decodeHex(cborHex);
+  return yield* fromBytes(transactionHash);
+});
+
+/**
+ * Create a TransactionHash from a CBOR hex string, throws on error.
+ *
+ * @example
+ * import { TransactionHash } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const transactionHash = TransactionHash.fromCBOROrThrow("581cc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+ * assert(transactionHash._tag === "TransactionHash");
+ * assert(transactionHash.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const fromCBOROrThrow = (cborHex: string) => {
+  const bytes = CBOR.decodeHexOrThrow(cborHex);
+  return fromBytesOrThrow(bytes);
+};
+
+/**
+ * Create a TransactionHash from CBOR bytes.
+ *
+ * @example
+ * import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+ * import { Effect } from "effect";
+ * import assert from "assert";
+ *
+ * const bytes = Bytes.fromHexOrThrow("581cc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+ * const transactionHashEffect = TransactionHash.fromCBORBytes(bytes);
+ * const transactionHash = Effect.runSync(transactionHashEffect);
+ * assert(transactionHash._tag === "TransactionHash");
+ * assert(transactionHash.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const fromCBORBytes: SerdeImpl.FromCBORBytes<
+  TransactionHash,
+  CBOR.CBORError | TransactionHashError
+> = Effect.fn(function* (cborBytes) {
+  const hashBytes = yield* CBOR.decode(cborBytes);
+  return yield* fromBytes(hashBytes);
+});
+
+/**
+ * Create a TransactionHash from CBOR bytes, throws on error.
+ *
+ * @example
+ * import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const bytes = Bytes.fromHexOrThrow("581cc37b1b5dc0669f1d3c61a6fddb2e8fde96be87b881c60bce8e8d542f");
+ * const transactionHash = TransactionHash.fromCBORBytesOrThrow(bytes);
+ * assert(transactionHash._tag === "TransactionHash");
+ * assert(transactionHash.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const fromCBORBytesOrThrow = (bytes: Uint8Array) =>
+  Effect.runSync(fromCBORBytes(bytes));
+
+/**
+ * Create a TransactionHash directly from bytes.
+ *
+ * @example
+ * import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+ * import { Effect } from "effect";
+ * import assert from "assert";
+ *
+ * const bytes = Bytes.fromHexOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const transactionHashEffect = TransactionHash.fromBytes(bytes);
+ * const transactionHash = Effect.runSync(transactionHashEffect);
+ * assert(transactionHash._tag === "TransactionHash");
+ * assert(transactionHash.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const fromBytes: SerdeImpl.FromBytes<
+  TransactionHash,
+  TransactionHashError
+> = Effect.fnUntraced(function* (bytes) {
+  if (bytes.length !== TRANSACTIONHASH_BYTES_LENGTH) {
+    return yield* new TransactionHashError({
+      message: `TransactionHash must be ${TRANSACTIONHASH_BYTES_LENGTH} bytes long, got: ${bytes.length}.`,
+    });
+  }
+  const hash = Bytes.toHexOrThrow(bytes);
+  return new TransactionHash({ hash }, { disableValidation: true });
+});
+
+/**
+ * Create a TransactionHash directly from bytes, throws on error.
+ *
+ * @example
+ * import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const bytes = Bytes.fromHexOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const transactionHash = TransactionHash.fromBytesOrThrow(bytes);
+ * assert(transactionHash._tag === "TransactionHash");
+ * assert(transactionHash.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const fromBytesOrThrow = (bytes: Uint8Array) => {
+  if (bytes.length !== TRANSACTIONHASH_BYTES_LENGTH) {
+    throw new TransactionHashError({
+      message: `TransactionHash must be ${TRANSACTIONHASH_BYTES_LENGTH} bytes long.`,
+    });
+  }
+  const hash = Bytes.toHexOrThrow(bytes);
+  return new TransactionHash({ hash }, { disableValidation: true });
+};
+
+/**
+ * Convert a TransactionHash to bytes.
+ *
+ * @example
+ * import { TransactionHash, Bytes } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const transactionHash = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const bytes = TransactionHash.toBytes(transactionHash);
+ * assert(bytes instanceof Uint8Array);
+ * assert(bytes.length === 32);
+ * assert(Bytes.toHexOrThrow(bytes) === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ *
+ * @since 2.0.0
+ * @category transformation
+ */
+export const toBytes: SerdeImpl.ToBytes<TransactionHash> = (transactionHash) =>
+  Bytes.fromHexOrThrow(transactionHash.hash);
+
+/**
+ * Construct a TransactionHash from a hex string.
+ *
+ * @example
+ * import { TransactionHash } from "@lucid-evolution/experimental";
+ * import { Effect } from "effect";
+ * import assert from "assert";
+ *
+ * const hash = "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
+ * const transactionHashEffect = TransactionHash.make(hash);
+ * const transactionHash = Effect.runSync(transactionHashEffect);
+ * assert(transactionHash._tag === "TransactionHash");
+ * assert(transactionHash.hash === hash);
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const make: SerdeImpl.Make<TransactionHash, TransactionHashError> =
+  Effect.fnUntraced(function* (hash) {
+    if (hash.length !== TRANSACTIONHASH_HEX_LENGTH) {
+      return yield* new TransactionHashError({
+        message: `TransactionHash must be ${TRANSACTIONHASH_HEX_LENGTH} characters long.`,
+      });
+    }
+    if (!Bytes.isHex(hash)) {
+      return yield* new TransactionHashError({
+        message: `TransactionHash must be a valid hex string.`,
+      });
+    }
+    return new TransactionHash({ hash }, { disableValidation: true });
+  });
+
+/**
+ * Construct a TransactionHash from a hex string, throws on error.
+ *
+ * @example
+ * import { TransactionHash } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const hash = "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
+ * const transactionHash = TransactionHash.makeOrThrow(hash);
+ * assert(transactionHash._tag === "TransactionHash");
+ * assert(transactionHash.hash === hash);
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const makeOrThrow: SerdeImpl.MakeOrThrow<TransactionHash> = (
+  hash: string,
+) => {
+  if (!Bytes.isHex(hash)) {
+    throw new TransactionHashError({
+      message: `TransactionHash must be a valid hex string.`,
+    });
+  }
+  if (hash.length !== TRANSACTIONHASH_HEX_LENGTH) {
+    throw new TransactionHashError({
+      message: `TransactionHash must be ${TRANSACTIONHASH_HEX_LENGTH} characters long.`,
+    });
+  }
+  return new TransactionHash({ hash }, { disableValidation: true });
+};
+
+/**
+ * Check if two TransactionHashes are equal.
+ *
+ * @example
+ * import { TransactionHash } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const hash1 = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const hash2 = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const hash3 = TransactionHash.makeOrThrow("dc97057e0949d9676e55b69f28fcb2dccb8002583a4ad761f1dbfb985f36085c");
+ *
+ * assert(TransactionHash.equals(hash1, hash2) === true);
+ * assert(TransactionHash.equals(hash1, hash3) === false);
+ *
+ * @since 2.0.0
+ * @category equality
+ */
+export const equals = (a: TransactionHash, b: TransactionHash): boolean =>
+  a.hash === b.hash;
+
+/**
+ * Generate a random TransactionHash using FastCheck.
+ *
+ * This is useful for testing purposes.
+ *
+ * @example
+ * import { TransactionHash } from "@lucid-evolution/experimental";
+ * import { FastCheck } from "effect";
+ * import assert from "assert";
+ *
+ * const randomSamples = FastCheck.sample(TransactionHash.generator, 20);
+ * randomSamples.forEach((transactionHash) => {
+ *  assert(transactionHash.hash.length === 64);
+ * });
+ *
+ * @since 2.0.0
+ * @category generators
+ */
+export const generator = FastCheck.uint8Array({
+  minLength: TRANSACTIONHASH_BYTES_LENGTH,
+  maxLength: TRANSACTIONHASH_BYTES_LENGTH,
+}).map((bytes) => fromBytesOrThrow(bytes));

--- a/packages/experimental/src/TransactionInput.ts
+++ b/packages/experimental/src/TransactionInput.ts
@@ -1,0 +1,243 @@
+import { Data, Effect, Inspectable, Schema } from "effect";
+import { Bytes } from "./index.js";
+import * as CBOR from "./CBOR.js";
+import * as SerdeImpl from "./SerdeImpl.js";
+import * as TransactionHash from "./TransactionHash.js";
+
+/**
+ * CDDL specs
+ * transaction_input = [transaction_id : $hash32, index : uint .size 2]
+ */
+
+/**
+ * Transaction input with transaction id and index
+ *
+ * @since 2.0.0
+ * @category schemas
+ */
+export class TransactionInput extends Schema.TaggedClass<TransactionInput>(
+  "TransactionInput",
+)("TransactionInput", {
+  transactionId: TransactionHash.TransactionHash,
+  index: Schema.Number,
+}) {
+  [Inspectable.NodeInspectSymbol]() {
+    return {
+      _tag: "TransactionInput",
+      transactionId: this.transactionId,
+      index: this.index,
+    };
+  }
+}
+
+/**
+ * Error thrown when transaction input operations fail
+ *
+ * @since 2.0.0
+ * @category model
+ */
+export class TransactionInputError extends Data.TaggedError(
+  "TransactionInputError",
+)<{
+  message: string;
+  cause?: unknown;
+}> {}
+
+/**
+ * Check if the given value is a valid TransactionInput
+ *
+ * @example
+ * import { TransactionInput } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const transactionInput = TransactionInput.makeOrThrow(0, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819")
+ * const isValid = TransactionInput.isTransactionInput(transactionInput);
+ * assert(isValid === true);
+ *
+ * @since 2.0.0
+ * @category predicates
+ */
+export const isTransactionInput = Schema.is(TransactionInput);
+
+/**
+ * Decode CBOR bytes to a TransactionInput
+ * Internal helper function used by fromCBOR
+ *
+ * @example
+ * import { TransactionInput, Bytes } from "@lucid-evolution/experimental";
+ * import { Effect } from "effect";
+ * import assert from "assert";
+ *
+ * const bytes = Bytes.fromHexOrThrow("TODO");
+ * const transactionInputEffect = TransactionInput.fromCBORBytes(bytes);
+ * const transactionInput = Effect.runSync(transactionInputEffect);
+ * assert(transactionInput.transactionId === "TODO");
+ * assert(transactionInput.index === 0);
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const fromCBORBytes: SerdeImpl.FromCBORBytes<
+  TransactionInput,
+  CBOR.CBORError | TransactionHash.TransactionHashError | TransactionInputError
+> = Effect.fnUntraced(function* (bytes) {
+  const [txHashBytes, index]: [Uint8Array, number] = yield* CBOR.decode(bytes);
+
+  const transactionId = yield* TransactionHash.fromBytes(txHashBytes);
+
+  return TransactionInput.make(
+    {
+      transactionId,
+      index,
+    },
+    { disableValidation: true },
+  );
+});
+
+/**
+ * Decode a CBOR hex string to a TransactionInput
+ *
+ * @example
+ * import { TransactionInput } from "@lucid-evolution/experimental";
+ * import { Effect } from "effect";
+ * import assert from "assert";
+ *
+ * const cborHex = "TODO";
+ * const transactionInputEffect = TransactionInput.fromCBOR(cborHex);
+ * const transactionInput = Effect.runSync(transactionInputEffect);
+ * assert(transactionInput.transactionId === "TODO");
+ * assert(transactionInput.index === 0);
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const fromCBOR: SerdeImpl.FromCBOR<
+  TransactionInput,
+  | CBOR.CBORError
+  | TransactionHash.TransactionHashError
+  | TransactionInputError
+  | Bytes.BytesError
+> = Effect.fn(function* (cborHex) {
+  const bytes = yield* Bytes.fromHex(cborHex);
+  return yield* fromCBORBytes(bytes);
+});
+
+/**
+ * Decode CBOR bytes to a TransactionInput, throws on error.
+ *
+ * @example
+ * import { TransactionInput, Bytes } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const bytes = Bytes.fromHexOrThrow("TODO");
+ * const transactionInput = TransactionInput.fromCBORBytesOrThrow(bytes);
+ * assert(transactionInput.transactionId === "TODO");
+ * assert(transactionInput.index === 0);
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const fromCBORBytesOrThrow: SerdeImpl.FromCBORBytesOrThrow<
+  TransactionInput
+> = (bytes) => Effect.runSync(fromCBORBytes(bytes));
+
+/**
+ * Decode a CBOR hex string to a TransactionInput, throws on error.
+ *
+ * @example
+ * import { TransactionInput } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const cborHex = "TODO";
+ * const transactionInput = TransactionInput.fromCBOROrThrow(cborHex);
+ * assert(transactionInput.transactionId === "TODO");
+ * assert(transactionInput.index === 0);
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const fromCBOROrThrow: SerdeImpl.FromCBOROrThrow<TransactionInput> = (
+  cborHex: string,
+) => {
+  const bytes = Bytes.fromHexOrThrow(cborHex);
+  return fromCBORBytesOrThrow(bytes);
+};
+
+/**
+ * Check if two TransactionInput instances are equal.
+ *
+ * @example
+ * import { TransactionInput } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const transactionInput = TransactionInput.makeOrThrow(0, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const sameTransactionInput = TransactionInput.makeOrThrow(0, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const differentTransactionInput1 = TransactionInput.makeOrThrow(1, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const differentTransactionInput2 = TransactionInput.makeOrThrow(0, "dddd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ *
+ * assert(TransactionInput.equals(transactionInput, sameTransactionInput) === true);
+ * assert(TransactionInput.equals(transactionInput, differentTransactionInput1) === false);
+ * assert(TransactionInput.equals(transactionInput, differentTransactionInput2) === false);
+ *
+ * @since 2.0.0
+ * @category equality
+ */
+export const equals = (a: TransactionInput, b: TransactionInput): boolean => {
+  return (
+    a._tag === b._tag &&
+    a.index === b.index &&
+    a.transactionId.hash === b.transactionId.hash
+  );
+};
+
+/**
+ * Convert TransactionInput to CBOR bytes
+ * Internal helper function used by toCBOR
+ *
+ * @example
+ * import { TransactionInput, Bytes } from "@lucid-evolution/experimental";
+ * import { Effect } from "effect";
+ * import assert from "assert";
+ *
+ * const transactionInput = TransactionInput.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const cborBytes = TransactionInput.toCBORBytes(transactionInput);
+ * // Verify the bytes are correct by converting back to hex
+ * const hexString = Bytes.toHexOrThrow(cborBytes);
+ * assert(hexString.startsWith("82"));  // Array of 2 elements in CBOR
+ * assert(hexString.includes("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819"));
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+const toCBORBytes: SerdeImpl.ToCBORBytes<TransactionInput> = (
+  transactionInput,
+) => {
+  return CBOR.encodeOrThrow([
+    transactionInput.index,
+    Bytes.fromHexOrThrow(transactionInput.transactionId.hash),
+  ]);
+};
+
+/**
+ * CBOR diagnostic notation for TransactionInput:
+ * transactionInput = [transactionId, index]
+ *
+ * CBOR hex for TransactionInput:
+ * [ 0, h'cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819' ]
+ *
+ * Convert TransactionInput to CBOR hex encoding
+ * Uses a pre-configured CBOR encoder for better performance
+ *
+ * @example
+ * import { TransactionInput } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const transactioninput = TransactionInput.makeOrThrow(0, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const cbor = TransactionInput.toCBOR(transactioninput);
+ * assert(cbor === "TODO");
+ *
+ * @since 2.0.0
+ * @category encoding/decoding
+ */
+export const toCBOR: SerdeImpl.ToCBOR<TransactionInput> = (transactionInput) =>
+  Bytes.toHexOrThrow(toCBORBytes(transactionInput));

--- a/packages/experimental/src/TransactionInput.ts
+++ b/packages/experimental/src/TransactionInput.ts
@@ -47,10 +47,11 @@ export class TransactionInputError extends Data.TaggedError(
  * Check if the given value is a valid TransactionInput
  *
  * @example
- * import { TransactionInput } from "@lucid-evolution/experimental";
+ * import { TransactionHash, TransactionInput } from "@lucid-evolution/experimental";
  * import assert from "assert";
  *
- * const transactionInput = TransactionInput.makeOrThrow(0, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819")
+ * const transactionId = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const transactionInput = TransactionInput.makeOrThrow(transactionId, 0)
  * const isValid = TransactionInput.isTransactionInput(transactionInput);
  * assert(isValid === true);
  *
@@ -68,10 +69,10 @@ export const isTransactionInput = Schema.is(TransactionInput);
  * import { Effect } from "effect";
  * import assert from "assert";
  *
- * const bytes = Bytes.fromHexOrThrow("TODO");
+ * const bytes = Bytes.fromHexOrThrow("82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * const transactionInputEffect = TransactionInput.fromCBORBytes(bytes);
  * const transactionInput = Effect.runSync(transactionInputEffect);
- * assert(transactionInput.transactionId === "TODO");
+ * assert(transactionInput.transactionId.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * assert(transactionInput.index === 0);
  *
  * @since 2.0.0
@@ -81,7 +82,7 @@ export const fromCBORBytes: SerdeImpl.FromCBORBytes<
   TransactionInput,
   CBOR.CBORError | TransactionHash.TransactionHashError | TransactionInputError
 > = Effect.fnUntraced(function* (bytes) {
-  const [txHashBytes, index]: [Uint8Array, number] = yield* CBOR.decode(bytes);
+  const [index, txHashBytes]: [number, Uint8Array] = yield* CBOR.decode(bytes);
 
   const transactionId = yield* TransactionHash.fromBytes(txHashBytes);
 
@@ -102,10 +103,10 @@ export const fromCBORBytes: SerdeImpl.FromCBORBytes<
  * import { Effect } from "effect";
  * import assert from "assert";
  *
- * const cborHex = "TODO";
+ * const cborHex = "82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
  * const transactionInputEffect = TransactionInput.fromCBOR(cborHex);
  * const transactionInput = Effect.runSync(transactionInputEffect);
- * assert(transactionInput.transactionId === "TODO");
+ * assert(transactionInput.transactionId.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * assert(transactionInput.index === 0);
  *
  * @since 2.0.0
@@ -129,9 +130,9 @@ export const fromCBOR: SerdeImpl.FromCBOR<
  * import { TransactionInput, Bytes } from "@lucid-evolution/experimental";
  * import assert from "assert";
  *
- * const bytes = Bytes.fromHexOrThrow("TODO");
+ * const bytes = Bytes.fromHexOrThrow("82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * const transactionInput = TransactionInput.fromCBORBytesOrThrow(bytes);
- * assert(transactionInput.transactionId === "TODO");
+ * assert(transactionInput.transactionId.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * assert(transactionInput.index === 0);
  *
  * @since 2.0.0
@@ -148,9 +149,9 @@ export const fromCBORBytesOrThrow: SerdeImpl.FromCBORBytesOrThrow<
  * import { TransactionInput } from "@lucid-evolution/experimental";
  * import assert from "assert";
  *
- * const cborHex = "TODO";
+ * const cborHex = "82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819";
  * const transactionInput = TransactionInput.fromCBOROrThrow(cborHex);
- * assert(transactionInput.transactionId === "TODO");
+ * assert(transactionInput.transactionId.hash === "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  * assert(transactionInput.index === 0);
  *
  * @since 2.0.0
@@ -167,14 +168,15 @@ export const fromCBOROrThrow: SerdeImpl.FromCBOROrThrow<TransactionInput> = (
  * Check if two TransactionInput instances are equal.
  *
  * @example
- * import { TransactionInput } from "@lucid-evolution/experimental";
+ * import { TransactionHash, TransactionInput } from "@lucid-evolution/experimental";
  * import assert from "assert";
  *
- * const transactionInput = TransactionInput.makeOrThrow(0, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
- * const sameTransactionInput = TransactionInput.makeOrThrow(0, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
- * const differentTransactionInput1 = TransactionInput.makeOrThrow(1, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
- * const differentTransactionInput2 = TransactionInput.makeOrThrow(0, "dddd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
- *
+ * const transactionId1 = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const transactionId2 = TransactionHash.makeOrThrow("dddd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const transactionInput = TransactionInput.makeOrThrow(transactionId1, 0);
+ * const sameTransactionInput = TransactionInput.makeOrThrow(transactionId1, 0);
+ * const differentTransactionInput1 = TransactionInput.makeOrThrow(transactionId1, 1);
+ * const differentTransactionInput2 = TransactionInput.makeOrThrow(transactionId2, 0);
  * assert(TransactionInput.equals(transactionInput, sameTransactionInput) === true);
  * assert(TransactionInput.equals(transactionInput, differentTransactionInput1) === false);
  * assert(TransactionInput.equals(transactionInput, differentTransactionInput2) === false);
@@ -195,21 +197,23 @@ export const equals = (a: TransactionInput, b: TransactionInput): boolean => {
  * Internal helper function used by toCBOR
  *
  * @example
- * import { TransactionInput, Bytes } from "@lucid-evolution/experimental";
+ * import { Bytes, TransactionHash, TransactionInput } from "@lucid-evolution/experimental";
  * import { Effect } from "effect";
  * import assert from "assert";
  *
- * const transactionInput = TransactionInput.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
- * const cborBytes = TransactionInput.toCBORBytes(transactionInput);
- * // Verify the bytes are correct by converting back to hex
- * const hexString = Bytes.toHexOrThrow(cborBytes);
- * assert(hexString.startsWith("82"));  // Array of 2 elements in CBOR
- * assert(hexString.includes("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819"));
+    const transactionId = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+    const transactionInput = TransactionInput.makeOrThrow(transactionId, 0)
+    const cborBytes = TransactionInput.toCBORBytes(transactionInput);
+    // Verify the bytes are correct by converting back to hex
+    const hexString = Bytes.toHexOrThrow(cborBytes);
+    // 82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819
+    assert(hexString.startsWith("82"));  // Array of 2 elements in CBOR
+    assert(hexString.includes("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819"));
  *
  * @since 2.0.0
  * @category encoding/decoding
  */
-const toCBORBytes: SerdeImpl.ToCBORBytes<TransactionInput> = (
+export const toCBORBytes: SerdeImpl.ToCBORBytes<TransactionInput> = (
   transactionInput,
 ) => {
   return CBOR.encodeOrThrow([
@@ -220,7 +224,7 @@ const toCBORBytes: SerdeImpl.ToCBORBytes<TransactionInput> = (
 
 /**
  * CBOR diagnostic notation for TransactionInput:
- * transactionInput = [transactionId, index]
+ * transactionInput = [index, transactionId]
  *
  * CBOR hex for TransactionInput:
  * [ 0, h'cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819' ]
@@ -229,15 +233,53 @@ const toCBORBytes: SerdeImpl.ToCBORBytes<TransactionInput> = (
  * Uses a pre-configured CBOR encoder for better performance
  *
  * @example
- * import { TransactionInput } from "@lucid-evolution/experimental";
+ * import { TransactionHash, TransactionInput } from "@lucid-evolution/experimental";
  * import assert from "assert";
  *
- * const transactioninput = TransactionInput.makeOrThrow(0, "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
- * const cbor = TransactionInput.toCBOR(transactioninput);
- * assert(cbor === "TODO");
+ * const transactionId = TransactionHash.makeOrThrow("cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
+ * const transactionInput = TransactionInput.makeOrThrow(transactionId, 0);
+ * const cbor = TransactionInput.toCBOR(transactionInput);
+ * assert(cbor === "82005820cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819");
  *
  * @since 2.0.0
  * @category encoding/decoding
  */
 export const toCBOR: SerdeImpl.ToCBOR<TransactionInput> = (transactionInput) =>
   Bytes.toHexOrThrow(toCBORBytes(transactionInput));
+
+/**
+ * Construct a TransactionInput, throws on error.
+ *
+ * @example
+ * import { TransactionHash, TransactionInput } from "@lucid-evolution/experimental";
+ * import assert from "assert";
+ *
+ * const transactionHash = "cefd2fcf657e5e5d6c35975f4e052f427819391b153ebb16ad8aa107ba5a3819"
+ * const transactionId = TransactionHash.makeOrThrow(transactionHash);
+ * const transactionInput = TransactionInput.makeOrThrow(transactionId, 0);
+ * assert(transactionInput._tag === "TransactionInput");
+ * assert(transactionInput.transactionId.hash === transactionHash);
+ * assert(transactionInput.index === 0);
+ *
+ * @since 2.0.0
+ * @category constructors
+ */
+export const makeOrThrow = (
+  transactionId: TransactionHash.TransactionHash,
+  index: number,
+): TransactionInput => {
+  if (!Number.isInteger(index) || index < 0) {
+    throw new TransactionInputError({
+      message: `TransactionInput index must be a non-negative integer, got: ${index}`,
+    });
+  }
+  if (index > 65535) {
+    throw new TransactionInputError({
+      message: `TransactionInput index is not a 2 byte number, got: ${index}`,
+    });
+  }
+  return new TransactionInput(
+    { transactionId, index },
+    { disableValidation: true },
+  );
+};

--- a/packages/experimental/src/index.ts
+++ b/packages/experimental/src/index.ts
@@ -18,6 +18,8 @@ export * as Header from "./Header.js";
 export * as Credential from "./Credential.js";
 export * as KeyHash from "./KeyHash.js";
 export * as ScriptHash from "./ScriptHash.js";
+export * as TransactionHash from "./TransactionHash.js";
+export * as TransactionInput from "./TransactionInput.js";
 export * as CBOR from "./CBOR.js";
 export * as Bech32 from "./Bech32.js";
 export * as Natural from "./Natural.js";


### PR DESCRIPTION
## Description

This PR is related to issue #592, more specifically to files `TransactionInput.ts` and `TransactionHash.ts`.

I have implemented functions for both files based on other files like ScriptHash/Address/Credential. The tests and comments are not yet finished, but I'd like to first discuss whether you see any issues with the current state of the PR so far (so I do not make tests, finish comments etc. and then realize it is completely wrong 😄 )

- In `fromCBORBytes` from the `TransactionInput.ts`, is building via make call in this case correct or is there a better approach? _(e.g. omitting make and replacing it with new)_
- Do you by any chance see some obvious mistakes that need fixing or anything missing?
- If the functions look good, then next would be finishing the **comments**, defining **tests** and generate **doc** via docgen. Is there something that I am missing? _(e.g. bumping version somewhere/updating changelog or something else)_

## Type of change

- [ ] 🔧 Bug fix
- [X] 💡 New feature
- [ ] 🔩 Performance improvement
- [x] 📚 Docs

If the feature is substantial or introduces breaking changes without a discussion, its best to open an [issue](https://github.com/Anastasia-Labs/lucid-evolution/issues) first.

## Checklist

- [x] I commented my code
- [ ] Added/modified unit tests
- [x] I made corresponding changes to the documentation

## Additional Notes

<!-- Any additional information we should know? -->
