### PR TITLE
fix evaluate tx with kupmios

### DIFF
--- a/packages/provider/src/kupmios.ts
+++ b/packages/provider/src/kupmios.ts
@@ -299,7 +299,7 @@ export class Kupmios implements Provider {
       method: "evaluateTransaction",
       params: {
         transaction: { cbor: tx },
-        additionalUtxo: Ogmios.toOgmiosUTxOs(additionalUTxOs),
+        // additionalUtxo: Ogmios.toOgmiosUTxOs(additionalUTxOs),
       },
       id: null,
     };


### PR DESCRIPTION
## Description
When I try to submit a transaction using Ogmios as the validator, I get an error like this:

<img width="1402" height="234" alt="image" src="https://github.com/user-attachments/assets/383d667c-3b3f-48ea-8cfe-8465142a7d96" />



I read the Ogmios documentation [Link](https://ogmios.dev/mini-protocols/local-tx-submission/) and saw the explanation for additionalUtxo: 
<img width="1465" height="920" alt="image" src="https://github.com/user-attachments/assets/ce18b48d-7df6-4d8a-ab5b-38c225c5a8f0" />

Currently, we are putting our inputs and reference inputs into additionalUtxo, but these are not “unknown or yet-to-be-known” UTxOs. I tried removing this field, and the transaction submitted successfully

Fixes # (issue)

## Type of change

- [x] 🔧 Bug fix
- [ ] 💡 New feature
- [ ] 🔩 Performance improvement
- [ ] 📚 Docs

If the feature is substantial or introduces breaking changes without a discussion, its best to open an [issue](https://github.com/Anastasia-Labs/lucid-evolution/issues) first.

## Checklist

- [ ] I commented my code
- [ ] Added/modified unit tests
- [ ] I made corresponding changes to the documentation

## Additional Notes

<!-- Any additional information we should know? -->
