### PR TITLE
feat: support Ogmios v7 and governance builders

### DIFF
--- a/.changeset/governance-vote-proposal-builders.md
+++ b/.changeset/governance-vote-proposal-builders.md
@@ -1,0 +1,6 @@
+---
+"@lucid-evolution/core-types": patch
+"@lucid-evolution/lucid": patch
+---
+
+Add first-class governance proposal and vote builders with key, native script, PlutusV3, and delayed redeemer support, using Conway ledger indexes for voting and proposing redeemers.

--- a/.changeset/ogmios-v7-protocol-parameters.md
+++ b/.changeset/ogmios-v7-protocol-parameters.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/provider": patch
+---
+
+Maintain Ogmios v6 compatibility while accepting the `maxReferenceScriptsSizePerTransaction` protocol parameter returned by Ogmios >=7.0.0.

--- a/.changeset/scalus-pv11-evaluator.md
+++ b/.changeset/scalus-pv11-evaluator.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/scalus-uplc": patch
+---
+
+Update Scalus to 0.18.1 for PV11-aware evaluator behavior.

--- a/packages/core-types/src/types.ts
+++ b/packages/core-types/src/types.ts
@@ -194,8 +194,20 @@ export type RedeemerPurpose =
       readonly redeemerListIndex: bigint | undefined;
     }
   | {
-      readonly tag: "publish" | "vote" | "propose";
+      readonly tag: "publish";
       readonly index: bigint;
+      readonly redeemerListIndex: bigint | undefined;
+    }
+  | {
+      readonly tag: "propose";
+      readonly index: bigint;
+      readonly proposalKey?: string;
+      readonly redeemerListIndex: bigint | undefined;
+    }
+  | {
+      readonly tag: "vote";
+      readonly index: bigint;
+      readonly voterKey?: string;
       readonly redeemerListIndex: bigint | undefined;
     };
 
@@ -388,6 +400,104 @@ export type DatumJson = {
 export type Anchor = {
   url: string;
   dataHash: string;
+};
+
+export type GovernanceActionId = {
+  txHash: TxHash;
+  index: number | bigint;
+};
+
+export type GovernanceVote = "No" | "Yes" | "Abstain";
+
+export type GovernanceVoter =
+  | {
+      type: "DRep";
+      credential: Credential;
+    }
+  | {
+      type: "ConstitutionalCommittee";
+      credential: Credential;
+    }
+  | {
+      type: "StakePool";
+      hash: KeyHash;
+    }
+  | {
+      type: "StakePool";
+      poolId: PoolId;
+    };
+
+export type GovernanceProtocolVersion = {
+  major: number | bigint;
+  minor: number | bigint;
+};
+
+export type GovernanceRational = {
+  numerator: number | bigint;
+  denominator: number | bigint;
+};
+
+export type GovernanceConstitution = {
+  anchor: Anchor;
+  scriptHash?: ScriptHash | null;
+};
+
+export type GovernanceAction =
+  | {
+      type: "ParameterChange";
+      actionId?: GovernanceActionId | null;
+      protocolParamUpdate: CML.ProtocolParamUpdate | string;
+      policyHash?: ScriptHash | null;
+    }
+  | {
+      type: "HardForkInitiation";
+      actionId?: GovernanceActionId | null;
+      protocolVersion: GovernanceProtocolVersion;
+    }
+  | {
+      type: "TreasuryWithdrawals";
+      withdrawals: Array<{
+        rewardAddress: RewardAddress;
+        amount: Lovelace;
+      }>;
+      policyHash?: ScriptHash | null;
+    }
+  | {
+      type: "NoConfidence";
+      actionId?: GovernanceActionId | null;
+    }
+  | {
+      type: "UpdateCommittee";
+      actionId?: GovernanceActionId | null;
+      remove: Credential[];
+      add: Array<{
+        credential: Credential;
+        epoch: number | bigint;
+      }>;
+      threshold: GovernanceRational;
+    }
+  | {
+      type: "NewConstitution";
+      actionId?: GovernanceActionId | null;
+      constitution: GovernanceConstitution;
+    }
+  | {
+      type: "InfoAction";
+    }
+  | {
+      type: "Cbor";
+      cbor: string;
+    }
+  | {
+      type: "CML";
+      action: CML.GovAction;
+    };
+
+export type GovernanceProposal = {
+  action: GovernanceAction;
+  returnAddress: RewardAddress;
+  anchor: Anchor;
+  deposit?: Lovelace;
 };
 
 export type AlwaysAbstain = {

--- a/packages/lucid/src/script-context/ScriptContext.ts
+++ b/packages/lucid/src/script-context/ScriptContext.ts
@@ -15,8 +15,10 @@ import { CML } from "../core.js";
 import {
   buildCanonicalRedeemerInfo,
   canonicalRedeemerEntries,
+  proposalProcedureForRedeemerIndex,
   type CanonicalRedeemerEntry,
   type CanonicalRedeemerInfo,
+  voterForRedeemerIndex,
 } from "../tx-builder/internal/RedeemerContext.js";
 import { ScriptPurposeData } from "./Schema.js";
 import type {
@@ -937,8 +939,9 @@ const scriptPurposeKey = (purpose: ScriptPurposeData): string =>
 const purposeFromRedeemerEntry = (
   entry: CanonicalRedeemerEntry,
   info: CanonicalRedeemerInfo,
-  body: CML.TransactionBody,
+  tx: CML.Transaction,
 ): ScriptPurposeData => {
+  const body = tx.body();
   switch (entry.tag) {
     case "spend": {
       const input = info.inputs[Number(entry.index)];
@@ -982,16 +985,14 @@ const purposeFromRedeemerEntry = (
       };
     }
     case "vote": {
-      const voter = toArray(body.voting_procedures()?.keys())[
-        Number(entry.index)
-      ];
+      const voter = voterForRedeemerIndex(tx, entry.index);
       if (!voter) {
         throw new Error(`Vote redeemer index ${entry.index} has no voter.`);
       }
       return { Voting: [voterFromCml(voter)] };
     }
     case "propose": {
-      const proposal = body.proposal_procedures()?.get(Number(entry.index));
+      const proposal = proposalProcedureForRedeemerIndex(tx, entry.index);
       if (!proposal) {
         throw new Error(
           `Propose redeemer index ${entry.index} has no proposal.`,
@@ -1021,7 +1022,7 @@ const redeemersFromWitnessSet = (
     };
   }
   const entries = canonicalRedeemerEntries(redeemers).map((entry) => {
-    const purpose = purposeFromRedeemerEntry(entry, info, tx.body());
+    const purpose = purposeFromRedeemerEntry(entry, info, tx);
     return [purpose, datumFromPlutusData(entry.data)] as const;
   });
   const sortedEntries = [...entries].sort(([left], [right]) =>

--- a/packages/lucid/src/tx-builder/TxBuilder.ts
+++ b/packages/lucid/src/tx-builder/TxBuilder.ts
@@ -7,6 +7,10 @@ import {
   Assets,
   BuildTxWithRedeemer,
   DRep,
+  GovernanceActionId,
+  GovernanceProposal,
+  GovernanceVote,
+  GovernanceVoter,
   Label,
   Lovelace,
   PaymentKeyHash,
@@ -33,6 +37,7 @@ import * as Signer from "./internal/Signer.js";
 import * as Stake from "./internal/Stake.js";
 import * as Pool from "./internal/Pool.js";
 import * as Governance from "./internal/Governance.js";
+import * as GovernanceAction from "./internal/GovernanceAction.js";
 import * as Metadata from "./internal/Metadata.js";
 import * as Treasury from "./internal/Treasury.js";
 import * as CompleteTxBuilder from "./internal/CompleteTxBuilder.js";
@@ -72,6 +77,7 @@ export type TxAction = {
 };
 
 type CertificateRedeemer = Redeemer | BuildTxWithRedeemer;
+type GovernanceRedeemer = Redeemer | BuildTxWithRedeemer;
 
 export type TxBuilderConfig = {
   readonly lucidConfig: LucidConfig;
@@ -93,6 +99,9 @@ export type TxBuilderConfig = {
   nextActionId: number;
   pendingRedeemers: PendingRedeemer[];
   witnessRegistry: Set<string>;
+  governanceVoteWitnessKeys: string[];
+  governanceProposalWitnessIndices: bigint[];
+  governanceProposalCount: bigint;
   certificateIndex: bigint;
   treasuryDonation: Treasury.TreasuryDonation | undefined;
   minFee: bigint | undefined;
@@ -169,6 +178,9 @@ export const makeTxBuilderConfig = (
   nextActionId: source?.nextActionId ?? 0,
   pendingRedeemers: [],
   witnessRegistry: new Set(),
+  governanceVoteWitnessKeys: [],
+  governanceProposalWitnessIndices: [],
+  governanceProposalCount: 0n,
   certificateIndex: 0n,
   treasuryDonation: undefined,
   minFee: source?.minFee,
@@ -483,6 +495,184 @@ const recordCertificateAction = (
   }
 };
 
+const replayVoteWithDelayedRedeemer = (
+  actionId: number,
+  pendingIds: readonly number[],
+  voter: GovernanceVoter,
+  redeemer: BuildTxWithRedeemer,
+  makeProgram: (
+    redeemer?: Redeemer,
+  ) => Effect.Effect<void, TransactionError, TxConfig>,
+  currentRedeemers: ReadonlyMap<number, Redeemer>,
+) =>
+  Effect.gen(function* () {
+    const { config } = yield* TxConfig;
+    if (voter.type === "StakePool" || voter.credential.type !== "Script") {
+      yield* txActionError(
+        "Delayed vote redeemer requires a Plutus vote witness",
+      );
+      return;
+    }
+
+    const script = config.scripts.get(voter.credential.hash);
+    const pendingId = pendingIds[0];
+    const delayedRedeemer = redeemerFor(currentRedeemers, pendingId);
+    if (!script) {
+      yield* makeProgram(delayedRedeemer);
+      return;
+    }
+    if (script.type === "Native") {
+      yield* makeProgram(undefined);
+      return;
+    }
+    yield* registerPendingRedeemer(config, {
+      id: pendingId,
+      actionId,
+      source: redeemer,
+      purposeKey: {
+        tag: "vote",
+        voterKey: GovernanceAction.governanceVoterKey(voter),
+      },
+    });
+    yield* makeProgram(delayedRedeemer);
+  });
+
+const recordVoteAction = (
+  config: TxBuilderConfig,
+  voter: GovernanceVoter,
+  actionId: GovernanceActionId,
+  voteChoice: GovernanceVote,
+  anchor?: Anchor,
+  redeemer?: GovernanceRedeemer,
+) => {
+  const voterSnapshot = GovernanceAction.cloneGovernanceVoter(voter);
+  const actionIdSnapshot = {
+    txHash: actionId.txHash,
+    index: actionId.index,
+  };
+  const anchorSnapshot = anchor ? { ...anchor } : undefined;
+  const redeemerSnapshot = cloneRedeemerInput(redeemer);
+  const isDelayed = isBuildTxWithRedeemer(redeemerSnapshot);
+  const makeProgram = (resolvedRedeemer?: Redeemer) =>
+    GovernanceAction.vote(
+      voterSnapshot,
+      actionIdSnapshot,
+      voteChoice,
+      anchorSnapshot,
+      resolvedRedeemer,
+    );
+
+  recordAction(config, isDelayed ? 1 : 0, (id, pendingIds) =>
+    makeAction(
+      id,
+      "vote",
+      pendingIds,
+      isDelayed,
+      (replayActionId, actionPendingIds) => (currentRedeemers) =>
+        isDelayed
+          ? replayVoteWithDelayedRedeemer(
+              replayActionId,
+              actionPendingIds,
+              voterSnapshot,
+              redeemerSnapshot,
+              makeProgram,
+              currentRedeemers,
+            )
+          : makeProgram(redeemerSnapshot as Redeemer | undefined),
+    ),
+  );
+
+  if (!isDelayed) {
+    config.programs.push(makeProgram(redeemerSnapshot as Redeemer | undefined));
+  }
+};
+
+const replayProposalWithDelayedRedeemer = (
+  actionId: number,
+  pendingIds: readonly number[],
+  proposal: GovernanceProposal,
+  redeemer: BuildTxWithRedeemer,
+  makeProgram: (
+    redeemer?: Redeemer,
+  ) => Effect.Effect<void, TransactionError, TxConfig>,
+  currentRedeemers: ReadonlyMap<number, Redeemer>,
+) =>
+  Effect.gen(function* () {
+    const { config } = yield* TxConfig;
+    const govAction = yield* GovernanceAction.toCMLGovernanceAction(
+      proposal.action,
+      config,
+    );
+    const scriptHash = govAction.script_hash()?.to_hex();
+    if (!scriptHash) {
+      yield* txActionError(
+        "Delayed proposal redeemer requires a Plutus proposal witness",
+      );
+      return;
+    }
+
+    const script = config.scripts.get(scriptHash);
+    const pendingId = pendingIds[0];
+    const delayedRedeemer = redeemerFor(currentRedeemers, pendingId);
+    if (!script) {
+      yield* makeProgram(delayedRedeemer);
+      return;
+    }
+    if (script.type === "Native") {
+      yield* makeProgram(undefined);
+      return;
+    }
+    yield* registerPendingRedeemer(config, {
+      id: pendingId,
+      actionId,
+      source: redeemer,
+      purposeKey: {
+        tag: "propose",
+        proposalKey: yield* GovernanceAction.governanceProposalKey(
+          proposal,
+          config,
+        ),
+      },
+    });
+    yield* makeProgram(delayedRedeemer);
+  });
+
+const recordProposalAction = (
+  config: TxBuilderConfig,
+  proposal: GovernanceProposal,
+  redeemer?: GovernanceRedeemer,
+) => {
+  const proposalSnapshot = GovernanceAction.cloneGovernanceProposal(proposal);
+  const redeemerSnapshot = cloneRedeemerInput(redeemer);
+  const isDelayed = isBuildTxWithRedeemer(redeemerSnapshot);
+  const makeProgram = (resolvedRedeemer?: Redeemer) =>
+    GovernanceAction.propose(proposalSnapshot, resolvedRedeemer);
+
+  recordAction(config, isDelayed ? 1 : 0, (id, pendingIds) =>
+    makeAction(
+      id,
+      "propose",
+      pendingIds,
+      isDelayed,
+      (replayActionId, actionPendingIds) => (currentRedeemers) =>
+        isDelayed
+          ? replayProposalWithDelayedRedeemer(
+              replayActionId,
+              actionPendingIds,
+              proposalSnapshot,
+              redeemerSnapshot,
+              makeProgram,
+              currentRedeemers,
+            )
+          : makeProgram(redeemerSnapshot as Redeemer | undefined),
+    ),
+  );
+
+  if (!isDelayed) {
+    config.programs.push(makeProgram(redeemerSnapshot as Redeemer | undefined));
+  }
+};
+
 export type TxBuilder = {
   readFrom: (utxos: UTxO[]) => TxBuilder;
   collectFrom: (
@@ -660,6 +850,17 @@ export type TxBuilder = {
     rewardAddress: RewardAddress,
     anchor?: Anchor,
     redeemer?: CertificateRedeemer,
+  ) => TxBuilder;
+  vote: (
+    voter: GovernanceVoter,
+    actionId: GovernanceActionId,
+    vote: GovernanceVote,
+    anchor?: Anchor,
+    redeemer?: GovernanceRedeemer,
+  ) => TxBuilder;
+  propose: (
+    proposal: GovernanceProposal,
+    redeemer?: GovernanceRedeemer,
   ) => TxBuilder;
   authCommitteeHot: (
     coldAddress: RewardAddress,
@@ -1299,6 +1500,20 @@ export function makeTxBuilder(lucidConfig: LucidConfig): TxBuilder {
         redeemer,
         rewardAddress,
       );
+      return txBuilder;
+    },
+    vote: (
+      voter: GovernanceVoter,
+      actionId: GovernanceActionId,
+      vote: GovernanceVote,
+      anchor?: Anchor,
+      redeemer?: GovernanceRedeemer,
+    ) => {
+      recordVoteAction(config, voter, actionId, vote, anchor, redeemer);
+      return txBuilder;
+    },
+    propose: (proposal: GovernanceProposal, redeemer?: GovernanceRedeemer) => {
+      recordProposalAction(config, proposal, redeemer);
       return txBuilder;
     },
     authCommitteeHot: (

--- a/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
+++ b/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
@@ -60,11 +60,14 @@ import {
   CanonicalRedeemerInfo,
   cloneUTxOs,
   normalizeEvalUTxO,
+  normalizeGovernanceRedeemerIndices,
+  proposalProcedureForRedeemerIndex,
   RedeemerBuilderCache,
   redeemerMapsEqual,
   resolveCanonicalInputs,
   resolveCanonicalReferenceInputs,
   transactionFixedPointFingerprint,
+  voterForRedeemerIndex,
 } from "./RedeemerContext.js";
 
 const MAX_EVALUATION_ATTEMPTS = 8;
@@ -287,8 +290,17 @@ const completeCurrentConfig = (
           builtTransaction.to_canonical_cbor_bytes(),
         )
       : builtTransaction;
+    const normalizedTransaction = yield* Effect.try({
+      try: () =>
+        normalizeGovernanceRedeemerIndices(
+          transactionBeforeScriptDataHash,
+          config.governanceVoteWitnessKeys,
+          config.governanceProposalWitnessIndices,
+        ).transaction,
+      catch: (error) => completeTxError(error),
+    });
     const transaction = yield* refreshScriptDataHash(
-      transactionBeforeScriptDataHash,
+      normalizedTransaction,
       config,
     );
 
@@ -644,6 +656,10 @@ export const applyEvaluationResult = (
   txbuilder: CML.TransactionBuilder,
   expectedKeys: Set<string>,
   evaluator?: string,
+  builderKeyByLedgerKey: ReadonlyMap<
+    string,
+    CML.RedeemerWitnessKey
+  > = new Map(),
 ): void => {
   if (expectedKeys.size > 0 && evalRedeemerList.length === 0) {
     throw evaluatorError(
@@ -679,10 +695,12 @@ export const applyEvaluationResult = (
       BigInt(evalRedeemer.ex_units.steps),
     );
     updates.push({
-      key: CML.RedeemerWitnessKey.new(
-        toCMLRedeemerTag(evalRedeemer.redeemer_tag),
-        BigInt(evalRedeemer.redeemer_index),
-      ),
+      key:
+        builderKeyByLedgerKey.get(key) ??
+        CML.RedeemerWitnessKey.new(
+          toCMLRedeemerTag(evalRedeemer.redeemer_tag),
+          BigInt(evalRedeemer.redeemer_index),
+        ),
       exUnits,
     });
   }
@@ -780,6 +798,34 @@ const scriptHashFromCertificate = (
       certificate.as_update_drep_cert()?.drep_credential(),
   );
 
+const voterByKey = (
+  body: CML.TransactionBody,
+  voterKey: string | undefined,
+): CML.Voter | undefined => {
+  if (!voterKey) return undefined;
+  const voters = body.voting_procedures()?.keys();
+  if (!voters) return undefined;
+  for (let i = 0; i < voters.len(); i++) {
+    const voter = voters.get(i);
+    if (voter.to_canonical_cbor_hex() === voterKey) return voter;
+  }
+  return undefined;
+};
+
+const proposalByKey = (
+  body: CML.TransactionBody,
+  proposalKey: string | undefined,
+): CML.ProposalProcedure | undefined => {
+  if (!proposalKey) return undefined;
+  const proposals = body.proposal_procedures();
+  if (!proposals) return undefined;
+  for (let i = 0; i < proposals.len(); i++) {
+    const proposal = proposals.get(i);
+    if (proposal.to_canonical_cbor_hex() === proposalKey) return proposal;
+  }
+  return undefined;
+};
+
 const scriptTypeToLanguage = (
   scriptType: ScriptType,
 ): CML.Language | undefined => {
@@ -808,6 +854,7 @@ const languageSortOrder = (language: CML.Language): number => {
 
 const scriptHashForPurpose = (
   purpose: RedeemerPurpose,
+  tx: CML.Transaction,
   info: CanonicalRedeemerInfo,
 ): string | undefined => {
   switch (purpose.tag) {
@@ -830,16 +877,15 @@ const scriptHashForPurpose = (
       return certificate ? scriptHashFromCertificate(certificate) : undefined;
     }
     case "vote": {
-      const voter = info.txBody
-        .voting_procedures()
-        ?.keys()
-        .get(Number(purpose.index));
+      const voter =
+        voterByKey(info.txBody, purpose.voterKey) ??
+        voterForRedeemerIndex(tx, purpose.index);
       return voter?.script_hash()?.to_hex();
     }
     case "propose": {
-      const proposal = info.txBody
-        .proposal_procedures()
-        ?.get(Number(purpose.index));
+      const proposal =
+        proposalByKey(info.txBody, purpose.proposalKey) ??
+        proposalProcedureForRedeemerIndex(tx, purpose.index);
       return proposal?.gov_action().script_hash()?.to_hex();
     }
   }
@@ -865,10 +911,10 @@ const usedPlutusLanguages = (
     const redeemerInfo = yield* buildCanonicalRedeemerInfo(tx, resolvedInputs);
 
     for (const purpose of redeemerInfo.redeemers) {
-      const scriptHash = scriptHashForPurpose(purpose, redeemerInfo);
+      const scriptHash = scriptHashForPurpose(purpose, tx, redeemerInfo);
       if (!scriptHash) {
         yield* completeTxError(
-          `Unable to resolve script hash for ${purpose.tag} redeemer`,
+          `Unable to resolve script hash for ${purpose.tag}:${purpose.index} redeemer`,
         );
         continue;
       }
@@ -1305,7 +1351,19 @@ const evaluateTransaction = (
   Effect.gen(function* () {
     const adapter = resolveEvaluatorAdapter(config, localUPLCEval, evaluator);
     const name = evaluatorName(adapter);
-    const txEvaluation = setRedeemerstoZero(tx)!;
+    const normalization = yield* Effect.try({
+      try: () =>
+        normalizeGovernanceRedeemerIndices(
+          tx,
+          config.governanceVoteWitnessKeys,
+          config.governanceProposalWitnessIndices,
+        ),
+      catch: (error) => wrapEvaluatorCause(error, name),
+    });
+    const txEvaluation = yield* refreshScriptDataHash(
+      setRedeemerstoZero(normalization.transaction),
+      config,
+    );
     const redeemers = txEvaluation.witness_set().redeemers();
     if (!redeemers) return;
     const expectedKeys = expectedRedeemerKeySet(redeemers);
@@ -1331,6 +1389,7 @@ const evaluateTransaction = (
           config.txBuilder,
           expectedKeys,
           name,
+          normalization.builderKeyByLedgerKey,
         ),
       catch: (error) => wrapEvaluatorCause(error, name),
     });

--- a/packages/lucid/src/tx-builder/internal/GovernanceAction.ts
+++ b/packages/lucid/src/tx-builder/internal/GovernanceAction.ts
@@ -1,0 +1,480 @@
+import {
+  Anchor,
+  Credential,
+  GovernanceAction,
+  GovernanceActionId,
+  GovernanceProposal,
+  GovernanceVoter,
+  GovernanceVote,
+  Redeemer,
+} from "@lucid-evolution/core-types";
+import * as CML from "@anastasia-labs/cardano-multiplatform-lib-nodejs";
+import { Effect, pipe } from "effect";
+import {
+  ERROR_MESSAGE,
+  TxBuilderError,
+  TransactionError,
+} from "../../Errors.js";
+import { TxConfig } from "./Service.js";
+import { toPartial, toV3, validateAddressDetails } from "./TxUtils.js";
+import type { TxBuilderConfig } from "../TxBuilder.js";
+
+export const governanceActionError = (cause: unknown) =>
+  new TxBuilderError({ cause: `{ GovernanceAction: ${cause} }` });
+
+const toBigInt = (value: number | bigint): bigint => BigInt(value);
+
+const cloneAnchor = (anchor: Anchor): Anchor => ({ ...anchor });
+
+const cloneCredential = (credential: Credential): Credential => ({
+  ...credential,
+});
+
+const cloneGovernanceActionId = (
+  actionId: GovernanceActionId | null | undefined,
+): GovernanceActionId | null | undefined =>
+  actionId === undefined || actionId === null
+    ? actionId
+    : { txHash: actionId.txHash, index: actionId.index };
+
+export const cloneGovernanceVoter = (
+  voter: GovernanceVoter,
+): GovernanceVoter => {
+  switch (voter.type) {
+    case "DRep":
+    case "ConstitutionalCommittee":
+      return {
+        type: voter.type,
+        credential: cloneCredential(voter.credential),
+      };
+    case "StakePool":
+      return "poolId" in voter
+        ? { type: "StakePool", poolId: voter.poolId }
+        : { type: "StakePool", hash: voter.hash };
+  }
+};
+
+export const cloneGovernanceAction = (
+  action: GovernanceAction,
+): GovernanceAction => {
+  switch (action.type) {
+    case "ParameterChange":
+      return {
+        type: "ParameterChange",
+        actionId: cloneGovernanceActionId(action.actionId),
+        protocolParamUpdate:
+          typeof action.protocolParamUpdate === "string"
+            ? action.protocolParamUpdate
+            : action.protocolParamUpdate.to_cbor_hex(),
+        policyHash: action.policyHash,
+      };
+    case "HardForkInitiation":
+      return {
+        type: "HardForkInitiation",
+        actionId: cloneGovernanceActionId(action.actionId),
+        protocolVersion: { ...action.protocolVersion },
+      };
+    case "TreasuryWithdrawals":
+      return {
+        type: "TreasuryWithdrawals",
+        withdrawals: action.withdrawals.map((withdrawal) => ({
+          ...withdrawal,
+        })),
+        policyHash: action.policyHash,
+      };
+    case "NoConfidence":
+      return {
+        type: "NoConfidence",
+        actionId: cloneGovernanceActionId(action.actionId),
+      };
+    case "UpdateCommittee":
+      return {
+        type: "UpdateCommittee",
+        actionId: cloneGovernanceActionId(action.actionId),
+        remove: action.remove.map(cloneCredential),
+        add: action.add.map((member) => ({
+          credential: cloneCredential(member.credential),
+          epoch: member.epoch,
+        })),
+        threshold: { ...action.threshold },
+      };
+    case "NewConstitution":
+      return {
+        type: "NewConstitution",
+        actionId: cloneGovernanceActionId(action.actionId),
+        constitution: {
+          anchor: cloneAnchor(action.constitution.anchor),
+          scriptHash: action.constitution.scriptHash,
+        },
+      };
+    case "InfoAction":
+      return { type: "InfoAction" };
+    case "Cbor":
+      return { type: "Cbor", cbor: action.cbor };
+    case "CML":
+      return { type: "Cbor", cbor: action.action.to_cbor_hex() };
+  }
+};
+
+export const cloneGovernanceProposal = (
+  proposal: GovernanceProposal,
+): GovernanceProposal => ({
+  action: cloneGovernanceAction(proposal.action),
+  returnAddress: proposal.returnAddress,
+  anchor: cloneAnchor(proposal.anchor),
+  deposit: proposal.deposit,
+});
+
+export const toCMLAnchor = (anchor: Anchor): CML.Anchor =>
+  CML.Anchor.new(
+    CML.Url.from_json(JSON.stringify(anchor.url)),
+    CML.AnchorDocHash.from_hex(anchor.dataHash),
+  );
+
+const toCMLCredential = (credential: Credential): CML.Credential => {
+  switch (credential.type) {
+    case "Key":
+      return CML.Credential.new_pub_key(
+        CML.Ed25519KeyHash.from_hex(credential.hash),
+      );
+    case "Script":
+      return CML.Credential.new_script(
+        CML.ScriptHash.from_hex(credential.hash),
+      );
+  }
+};
+
+const toCMLScriptHash = (
+  scriptHash: string | null | undefined,
+): CML.ScriptHash | undefined =>
+  scriptHash === undefined || scriptHash === null
+    ? undefined
+    : CML.ScriptHash.from_hex(scriptHash);
+
+const toCMLGovernanceActionId = (
+  actionId: GovernanceActionId | null | undefined,
+): CML.GovActionId | undefined =>
+  actionId === undefined || actionId === null
+    ? undefined
+    : CML.GovActionId.new(
+        CML.TransactionHash.from_hex(actionId.txHash),
+        toBigInt(actionId.index),
+      );
+
+const toCMLProtocolParamUpdate = (
+  update: CML.ProtocolParamUpdate | string,
+): CML.ProtocolParamUpdate =>
+  typeof update === "string"
+    ? CML.ProtocolParamUpdate.from_cbor_hex(update)
+    : update;
+
+const toCMLRewardAddress = (
+  rewardAddress: string,
+  config: TxBuilderConfig,
+): Effect.Effect<CML.RewardAddress, TxBuilderError> =>
+  Effect.gen(function* () {
+    const addressDetails = yield* pipe(
+      validateAddressDetails(rewardAddress, config.lucidConfig),
+      Effect.andThen((details) =>
+        details.type !== "Reward"
+          ? governanceActionError(ERROR_MESSAGE.MISSING_REWARD_TYPE)
+          : Effect.succeed(details),
+      ),
+    );
+    const cmlRewardAddress = CML.RewardAddress.from_address(
+      CML.Address.from_bech32(addressDetails.address.bech32),
+    );
+    if (!cmlRewardAddress) {
+      yield* governanceActionError(ERROR_MESSAGE.MISSING_REWARD_TYPE);
+    }
+    return cmlRewardAddress!;
+  });
+
+export const toCMLGovernanceAction = (
+  action: GovernanceAction,
+  config: TxBuilderConfig,
+): Effect.Effect<CML.GovAction, TxBuilderError> =>
+  Effect.gen(function* () {
+    switch (action.type) {
+      case "ParameterChange":
+        return CML.GovAction.new_parameter_change_action(
+          toCMLGovernanceActionId(action.actionId),
+          toCMLProtocolParamUpdate(action.protocolParamUpdate),
+          toCMLScriptHash(action.policyHash),
+        );
+      case "HardForkInitiation":
+        return CML.GovAction.new_hard_fork_initiation_action(
+          toCMLGovernanceActionId(action.actionId),
+          CML.ProtocolVersion.new(
+            toBigInt(action.protocolVersion.major),
+            toBigInt(action.protocolVersion.minor),
+          ),
+        );
+      case "TreasuryWithdrawals": {
+        const withdrawals = CML.MapRewardAccountToCoin.new();
+        const seen = new Set<string>();
+        for (const withdrawal of action.withdrawals) {
+          const rewardAddress = yield* toCMLRewardAddress(
+            withdrawal.rewardAddress,
+            config,
+          );
+          const rewardAddressKey = rewardAddress
+            .to_address()
+            .to_bech32(undefined);
+          if (seen.has(rewardAddressKey)) {
+            yield* governanceActionError(
+              `Duplicate treasury withdrawal address: ${withdrawal.rewardAddress}`,
+            );
+          }
+          seen.add(rewardAddressKey);
+          withdrawals.insert(rewardAddress, withdrawal.amount);
+        }
+        return CML.GovAction.new_treasury_withdrawals_action(
+          withdrawals,
+          toCMLScriptHash(action.policyHash),
+        );
+      }
+      case "NoConfidence":
+        return CML.GovAction.new_no_confidence(
+          toCMLGovernanceActionId(action.actionId),
+        );
+      case "UpdateCommittee": {
+        const remove = CML.CommitteeColdCredentialList.new();
+        for (const credential of action.remove) {
+          remove.add(toCMLCredential(credential));
+        }
+        const add = CML.MapCommitteeColdCredentialToEpoch.new();
+        for (const member of action.add) {
+          add.insert(
+            toCMLCredential(member.credential),
+            toBigInt(member.epoch),
+          );
+        }
+        return CML.GovAction.new_update_committee(
+          toCMLGovernanceActionId(action.actionId),
+          remove,
+          add,
+          CML.UnitInterval.new(
+            toBigInt(action.threshold.numerator),
+            toBigInt(action.threshold.denominator),
+          ),
+        );
+      }
+      case "NewConstitution":
+        return CML.GovAction.new_new_constitution(
+          toCMLGovernanceActionId(action.actionId),
+          CML.Constitution.new(
+            toCMLAnchor(action.constitution.anchor),
+            toCMLScriptHash(action.constitution.scriptHash),
+          ),
+        );
+      case "InfoAction":
+        return CML.GovAction.new_info_action();
+      case "Cbor":
+        return CML.GovAction.from_cbor_hex(action.cbor);
+      case "CML":
+        return action.action;
+    }
+  });
+
+export const toCMLVoter = (voter: GovernanceVoter): CML.Voter => {
+  switch (voter.type) {
+    case "DRep":
+      return voter.credential.type === "Key"
+        ? CML.Voter.new_d_rep_key_hash(
+            CML.Ed25519KeyHash.from_hex(voter.credential.hash),
+          )
+        : CML.Voter.new_d_rep_script_hash(
+            CML.ScriptHash.from_hex(voter.credential.hash),
+          );
+    case "ConstitutionalCommittee":
+      return voter.credential.type === "Key"
+        ? CML.Voter.new_constitutional_committee_hot_key_hash(
+            CML.Ed25519KeyHash.from_hex(voter.credential.hash),
+          )
+        : CML.Voter.new_constitutional_committee_hot_script_hash(
+            CML.ScriptHash.from_hex(voter.credential.hash),
+          );
+    case "StakePool":
+      return CML.Voter.new_staking_pool_key_hash(
+        "poolId" in voter
+          ? CML.Ed25519KeyHash.from_bech32(voter.poolId)
+          : CML.Ed25519KeyHash.from_hex(voter.hash),
+      );
+  }
+};
+
+export const governanceVoterKey = (voter: GovernanceVoter): string =>
+  toCMLVoter(voter).to_canonical_cbor_hex();
+
+export const toCMLProposalProcedure = (
+  proposal: GovernanceProposal,
+  config: TxBuilderConfig,
+): Effect.Effect<CML.ProposalProcedure, TxBuilderError> =>
+  Effect.gen(function* () {
+    return CML.ProposalProcedure.new(
+      proposal.deposit ??
+        config.lucidConfig.protocolParameters.govActionDeposit,
+      yield* toCMLRewardAddress(proposal.returnAddress, config),
+      yield* toCMLGovernanceAction(proposal.action, config),
+      toCMLAnchor(proposal.anchor),
+    );
+  });
+
+export const governanceProposalKey = (
+  proposal: GovernanceProposal,
+  config: TxBuilderConfig,
+): Effect.Effect<string, TxBuilderError> =>
+  Effect.gen(function* () {
+    const proposalProcedure = yield* toCMLProposalProcedure(proposal, config);
+    return proposalProcedure.to_canonical_cbor_hex();
+  });
+
+const toCMLVote = (vote: GovernanceVote): CML.Vote => {
+  switch (vote) {
+    case "No":
+      return CML.Vote.No;
+    case "Yes":
+      return CML.Vote.Yes;
+    case "Abstain":
+      return CML.Vote.Abstain;
+  }
+};
+
+const voterCredential = (voter: GovernanceVoter): Credential | undefined =>
+  voter.type === "StakePool" ? undefined : voter.credential;
+
+export const vote = (
+  voter: GovernanceVoter,
+  actionId: GovernanceActionId,
+  voteChoice: GovernanceVote,
+  anchor?: Anchor,
+  redeemer?: Redeemer,
+): Effect.Effect<void, TransactionError, TxConfig> =>
+  Effect.gen(function* () {
+    const { config } = yield* TxConfig;
+    const cmlVoter = toCMLVoter(voter);
+    const cmlActionId = toCMLGovernanceActionId(actionId)!;
+    const procedure = CML.VotingProcedure.new(
+      toCMLVote(voteChoice),
+      anchor ? toCMLAnchor(anchor) : undefined,
+    );
+    let builder = CML.VoteBuilder.new();
+    const credential = voterCredential(voter);
+
+    if (!credential || credential.type === "Key") {
+      builder = builder.with_vote(cmlVoter, cmlActionId, procedure);
+    } else {
+      const script = yield* pipe(
+        Effect.fromNullable(config.scripts.get(credential.hash)),
+        Effect.orElseFail(() =>
+          governanceActionError(ERROR_MESSAGE.MISSING_SCRIPT(credential.hash)),
+        ),
+      );
+
+      if (script.type === "Native") {
+        builder = builder.with_native_script_vote(
+          cmlVoter,
+          cmlActionId,
+          procedure,
+          CML.NativeScript.from_cbor_hex(script.script),
+          CML.NativeScriptWitnessInfo.assume_signature_count(),
+        );
+      } else {
+        if (script.type !== "PlutusV3") {
+          yield* governanceActionError(
+            "Governance voting scripts must use PlutusV3",
+          );
+        }
+        const voterKey = cmlVoter.to_canonical_cbor_hex();
+        if (config.governanceVoteWitnessKeys.includes(voterKey)) {
+          yield* governanceActionError(
+            "Multiple Plutus voting procedures for the same voter are not supported in one transaction",
+          );
+        }
+        const red = yield* pipe(
+          Effect.fromNullable(redeemer),
+          Effect.orElseFail(() =>
+            governanceActionError(ERROR_MESSAGE.MISSING_REDEEMER),
+          ),
+        );
+        const partial = toPartial(toV3(script.script), red);
+        builder = builder.with_plutus_vote(
+          cmlVoter,
+          cmlActionId,
+          procedure,
+          partial,
+          CML.Ed25519KeyHashList.new(),
+          CML.PlutusData.from_cbor_hex(red),
+        );
+      }
+    }
+
+    yield* Effect.try({
+      try: () => config.txBuilder.add_vote(builder.build()),
+      catch: governanceActionError,
+    });
+    if (credential?.type === "Script") {
+      config.governanceVoteWitnessKeys.push(cmlVoter.to_canonical_cbor_hex());
+    }
+  });
+
+export const propose = (
+  proposal: GovernanceProposal,
+  redeemer?: Redeemer,
+): Effect.Effect<void, TransactionError, TxConfig> =>
+  Effect.gen(function* () {
+    const { config } = yield* TxConfig;
+    const proposalProcedure = yield* toCMLProposalProcedure(proposal, config);
+    const proposalIndex = config.governanceProposalCount;
+    const govAction = proposalProcedure.gov_action();
+    let builder = CML.ProposalBuilder.new();
+    const scriptHash = govAction.script_hash()?.to_hex();
+
+    if (!scriptHash) {
+      builder = builder.with_proposal(proposalProcedure);
+    } else {
+      const script = yield* pipe(
+        Effect.fromNullable(config.scripts.get(scriptHash)),
+        Effect.orElseFail(() =>
+          governanceActionError(ERROR_MESSAGE.MISSING_SCRIPT(scriptHash)),
+        ),
+      );
+
+      if (script.type === "Native") {
+        builder = builder.with_native_script_proposal(
+          proposalProcedure,
+          CML.NativeScript.from_cbor_hex(script.script),
+          CML.NativeScriptWitnessInfo.assume_signature_count(),
+        );
+      } else {
+        if (script.type !== "PlutusV3") {
+          yield* governanceActionError(
+            "Governance proposal scripts must use PlutusV3",
+          );
+        }
+        const red = yield* pipe(
+          Effect.fromNullable(redeemer),
+          Effect.orElseFail(() =>
+            governanceActionError(ERROR_MESSAGE.MISSING_REDEEMER),
+          ),
+        );
+        const partial = toPartial(toV3(script.script), red);
+        builder = builder.with_plutus_proposal(
+          proposalProcedure,
+          partial,
+          CML.Ed25519KeyHashList.new(),
+          CML.PlutusData.from_cbor_hex(red),
+        );
+      }
+    }
+
+    yield* Effect.try({
+      try: () => config.txBuilder.add_proposal(builder.build()),
+      catch: governanceActionError,
+    });
+    config.governanceProposalCount += 1n;
+    if (scriptHash) {
+      config.governanceProposalWitnessIndices.push(proposalIndex);
+    }
+  });

--- a/packages/lucid/src/tx-builder/internal/RedeemerContext.ts
+++ b/packages/lucid/src/tx-builder/internal/RedeemerContext.ts
@@ -31,7 +31,11 @@ export type WitnessPurposeKey =
   | { readonly tag: "spend"; readonly input: OutRef }
   | { readonly tag: "mint"; readonly policyId: PolicyId }
   | { readonly tag: "withdraw"; readonly rewardAddress: RewardAddress }
-  | { readonly tag: "publish" | "vote" | "propose"; readonly index: bigint };
+  | { readonly tag: "publish"; readonly index: bigint }
+  | { readonly tag: "propose"; readonly index: bigint }
+  | { readonly tag: "propose"; readonly proposalKey: string }
+  | { readonly tag: "vote"; readonly index: bigint }
+  | { readonly tag: "vote"; readonly voterKey: string };
 
 export type PendingRedeemer = Readonly<{
   id: number;
@@ -136,9 +140,15 @@ export const witnessPurposeKey = (purposeKey: WitnessPurposeKey): string => {
     case "withdraw":
       return `withdraw:${purposeKey.rewardAddress}`;
     case "publish":
-    case "vote":
-    case "propose":
       return `${purposeKey.tag}:${purposeKey.index}`;
+    case "propose":
+      return "proposalKey" in purposeKey
+        ? `propose:proposal:${purposeKey.proposalKey}`
+        : `propose:${purposeKey.index}`;
+    case "vote":
+      return "voterKey" in purposeKey
+        ? `vote:voter:${purposeKey.voterKey}`
+        : `vote:${purposeKey.index}`;
   }
 };
 
@@ -153,9 +163,15 @@ export const purposeToWitnessKey = (
     case "withdraw":
       return { tag: "withdraw", rewardAddress: purpose.rewardAddress };
     case "publish":
-    case "vote":
-    case "propose":
       return { tag: purpose.tag, index: purpose.index };
+    case "propose":
+      return purpose.proposalKey
+        ? { tag: "propose", proposalKey: purpose.proposalKey }
+        : { tag: "propose", index: purpose.index };
+    case "vote":
+      return purpose.voterKey
+        ? { tag: "vote", voterKey: purpose.voterKey }
+        : { tag: "vote", index: purpose.index };
   }
 };
 
@@ -297,6 +313,189 @@ const deriveWithdrawals = (
 const redeemerKeyBytes = (tag: CML.RedeemerTag, index: bigint): Uint8Array =>
   CML.RedeemerKey.new(tag, index).to_canonical_cbor_bytes();
 
+const cmlVoterKey = (voter: CML.Voter): string => voter.to_canonical_cbor_hex();
+
+const cmlProposalKey = (proposal: CML.ProposalProcedure): string =>
+  proposal.to_canonical_cbor_hex();
+
+const indexToSafeNumber = (index: bigint): number | undefined => {
+  if (index < 0n || index > BigInt(Number.MAX_SAFE_INTEGER)) return undefined;
+  return Number(index);
+};
+
+export const proposalProcedureForRedeemerIndex = (
+  tx: CML.Transaction,
+  index: bigint,
+): CML.ProposalProcedure | undefined => {
+  const proposals = tx.body().proposal_procedures();
+  if (!proposals) return undefined;
+  const target = indexToSafeNumber(index);
+  if (target === undefined) return undefined;
+
+  return target < proposals.len() ? proposals.get(target) : undefined;
+};
+
+export const voterForRedeemerIndex = (
+  tx: CML.Transaction,
+  index: bigint,
+): CML.Voter | undefined => {
+  const voters = tx.body().voting_procedures()?.keys();
+  if (!voters) return undefined;
+  const target = indexToSafeNumber(index);
+  if (target === undefined) return undefined;
+
+  return target < voters.len() ? voters.get(target) : undefined;
+};
+
+export type GovernanceRedeemerNormalization = Readonly<{
+  transaction: CML.Transaction;
+  builderKeyByLedgerKey: ReadonlyMap<string, CML.RedeemerWitnessKey>;
+}>;
+
+const voterIndexByKey = (
+  tx: CML.Transaction,
+  voterKey: string,
+): bigint | undefined => {
+  const voters = tx.body().voting_procedures()?.keys();
+  if (!voters) return undefined;
+  for (let i = 0; i < voters.len(); i++) {
+    if (cmlVoterKey(voters.get(i)) === voterKey) return BigInt(i);
+  }
+  return undefined;
+};
+
+const governanceIndex = (
+  tx: CML.Transaction,
+  tag: RedeemerTag,
+  rawIndex: bigint,
+  voteWitnessKeys: readonly string[],
+  proposalWitnessIndices: readonly bigint[],
+): bigint => {
+  if (tag !== "vote" && tag !== "propose") return rawIndex;
+  const witnessIndex = indexToSafeNumber(rawIndex);
+  if (witnessIndex === undefined) {
+    throw redeemerContextError(
+      `Governance redeemer index ${rawIndex} is outside the safe integer range`,
+    );
+  }
+  if (tag === "propose") {
+    if (proposalWitnessIndices.length === 0) return rawIndex;
+    const ledgerIndex = proposalWitnessIndices[witnessIndex];
+    const proposals = tx.body().proposal_procedures();
+    if (
+      ledgerIndex === undefined ||
+      !proposals ||
+      ledgerIndex < 0n ||
+      ledgerIndex >= BigInt(proposals.len())
+    ) {
+      throw redeemerContextError(
+        `Unable to map proposing redeemer index ${rawIndex} to a proposal procedure`,
+      );
+    }
+    return ledgerIndex;
+  }
+  if (voteWitnessKeys.length === 0) return rawIndex;
+  const voterKey = voteWitnessKeys[witnessIndex];
+  const ledgerIndex = voterKey ? voterIndexByKey(tx, voterKey) : undefined;
+  if (ledgerIndex === undefined) {
+    throw redeemerContextError(
+      `Unable to map voting redeemer index ${rawIndex} to a voter`,
+    );
+  }
+  return ledgerIndex;
+};
+
+export const normalizeGovernanceRedeemerIndices = (
+  tx: CML.Transaction,
+  voteWitnessKeys: readonly string[],
+  proposalWitnessIndices: readonly bigint[],
+): GovernanceRedeemerNormalization => {
+  const transaction = CML.Transaction.from_cbor_bytes(tx.to_cbor_bytes());
+  const ledgerIndexTransaction = CML.Transaction.from_cbor_bytes(
+    tx.to_canonical_cbor_bytes(),
+  );
+  const witnessSet = transaction.witness_set();
+  const redeemers = witnessSet.redeemers();
+  const builderKeyByLedgerKey = new Map<string, CML.RedeemerWitnessKey>();
+  if (!redeemers) return { transaction, builderKeyByLedgerKey };
+
+  const seen = new Set<string>();
+  const normalizeKey = (tag: CML.RedeemerTag, index: bigint): bigint => {
+    const lucidTag = fromCMLRedeemerTag(tag);
+    const normalizedIndex = governanceIndex(
+      ledgerIndexTransaction,
+      lucidTag,
+      index,
+      voteWitnessKeys,
+      proposalWitnessIndices,
+    );
+    const ledgerKey = `${lucidTag}:${normalizedIndex}`;
+    if (seen.has(ledgerKey)) {
+      throw redeemerContextError(
+        `Multiple builder redeemers map to ledger purpose ${ledgerKey}`,
+      );
+    }
+    seen.add(ledgerKey);
+    builderKeyByLedgerKey.set(
+      ledgerKey,
+      CML.RedeemerWitnessKey.new(tag, index),
+    );
+    return normalizedIndex;
+  };
+
+  const legacy = redeemers.as_arr_legacy_redeemer();
+  if (legacy) {
+    const normalized = CML.LegacyRedeemerList.new();
+    for (let i = 0; i < legacy.len(); i++) {
+      const redeemer = legacy.get(i);
+      normalized.add(
+        CML.LegacyRedeemer.new(
+          redeemer.tag(),
+          normalizeKey(redeemer.tag(), redeemer.index()),
+          redeemer.data(),
+          redeemer.ex_units(),
+        ),
+      );
+    }
+    witnessSet.set_redeemers(CML.Redeemers.new_arr_legacy_redeemer(normalized));
+    return {
+      transaction: CML.Transaction.new(
+        transaction.body(),
+        witnessSet,
+        transaction.is_valid(),
+        transaction.auxiliary_data(),
+      ),
+      builderKeyByLedgerKey,
+    };
+  }
+
+  const map = redeemers.as_map_redeemer_key_to_redeemer_val();
+  if (map) {
+    const normalized = CML.MapRedeemerKeyToRedeemerVal.new();
+    const keys = map.keys();
+    for (let i = 0; i < keys.len(); i++) {
+      const key = keys.get(i);
+      normalized.insert(
+        CML.RedeemerKey.new(key.tag(), normalizeKey(key.tag(), key.index())),
+        map.get(key)!,
+      );
+    }
+    witnessSet.set_redeemers(
+      CML.Redeemers.new_map_redeemer_key_to_redeemer_val(normalized),
+    );
+    return {
+      transaction: CML.Transaction.new(
+        transaction.body(),
+        witnessSet,
+        transaction.is_valid(),
+        transaction.auxiliary_data(),
+      ),
+      builderKeyByLedgerKey,
+    };
+  }
+  return { transaction, builderKeyByLedgerKey };
+};
+
 const compareBytes = (a: Uint8Array, b: Uint8Array): number => {
   if (a.length !== b.length) return a.length - b.length;
   for (let i = 0; i < a.length; i++) {
@@ -418,10 +617,28 @@ const deriveRedeemerPurposes = (
           break;
         }
         case "publish":
-        case "vote":
-        case "propose":
           purposes.push({ tag, index, redeemerListIndex });
           break;
+        case "propose": {
+          const proposal = proposalProcedureForRedeemerIndex(tx, index);
+          purposes.push({
+            tag,
+            index,
+            proposalKey: proposal ? cmlProposalKey(proposal) : undefined,
+            redeemerListIndex,
+          });
+          break;
+        }
+        case "vote": {
+          const voter = voterForRedeemerIndex(tx, index);
+          purposes.push({
+            tag,
+            index,
+            voterKey: voter ? cmlVoterKey(voter) : undefined,
+            redeemerListIndex,
+          });
+          break;
+        }
       }
     }
     return purposes;
@@ -472,8 +689,26 @@ export const buildCanonicalRedeemerInfo = (
     redeemers.forEach((purpose) => {
       const key = witnessPurposeKey(purposeToWitnessKey(purpose));
       purposeByKey.set(key, purpose);
+      if (purpose.tag === "vote" && purpose.voterKey) {
+        purposeByKey.set(`vote:${purpose.index}`, purpose);
+      }
+      if (purpose.tag === "propose" && purpose.proposalKey) {
+        purposeByKey.set(`propose:${purpose.index}`, purpose);
+      }
       if (purpose.redeemerListIndex !== undefined) {
         redeemerIndices.set(key, purpose.redeemerListIndex);
+        if (purpose.tag === "vote" && purpose.voterKey) {
+          redeemerIndices.set(
+            `vote:${purpose.index}`,
+            purpose.redeemerListIndex,
+          );
+        }
+        if (purpose.tag === "propose" && purpose.proposalKey) {
+          redeemerIndices.set(
+            `propose:${purpose.index}`,
+            purpose.redeemerListIndex,
+          );
+        }
       }
     });
 

--- a/packages/lucid/test/redeemer-context-internal.test.ts
+++ b/packages/lucid/test/redeemer-context-internal.test.ts
@@ -3,6 +3,8 @@ import { Effect } from "effect";
 import {
   BuildTxWithRedeemer,
   CML,
+  GovernanceAction,
+  GovernanceProposal,
   Provider,
   RedeemerBuilder,
   Script,
@@ -48,6 +50,10 @@ const lucidConfig = {
 const alwaysSucceedScript: Script = {
   type: "PlutusV2",
   script: "49480100002221200101",
+};
+const secondPlutusV3Script: Script = {
+  type: "PlutusV3",
+  script: "46010000249900",
 };
 
 const scriptAddress = validatorToAddress("Custom", alwaysSucceedScript);
@@ -138,6 +144,11 @@ const makeUtxo = (byte: string, outputIndex = 0): UTxO => ({
   assets: { lovelace: 5_000_000n },
 });
 
+const makeRichUtxo = (byte: string, outputIndex = 0): UTxO => ({
+  ...makeUtxo(byte, outputIndex),
+  assets: { lovelace: 1_000_000_000_000n },
+});
+
 const makeRewardAddress = (byte: string): CML.RewardAddress =>
   CML.RewardAddress.new(
     0,
@@ -146,6 +157,43 @@ const makeRewardAddress = (byte: string): CML.RewardAddress =>
 
 const rewardAddressBech32 = (rewardAddress: CML.RewardAddress): string =>
   rewardAddress.to_address().to_bech32(undefined);
+
+const governanceAnchor = {
+  url: "https://example.com/governance",
+  dataHash: "77".repeat(32),
+};
+
+const governanceReturnAddress = credentialToRewardAddress("Custom", {
+  type: "Key",
+  hash: "66".repeat(28),
+});
+
+const governanceActionId = {
+  txHash: "ab".repeat(32),
+  index: 0n,
+};
+
+const parameterChangeAction = (policyHash: string): GovernanceAction => {
+  const update = CML.ProtocolParamUpdate.new();
+  update.set_minfee_a(44n);
+  return {
+    type: "ParameterChange",
+    protocolParamUpdate: update,
+    policyHash,
+  };
+};
+
+const infoProposal = (): GovernanceProposal => ({
+  action: { type: "InfoAction" },
+  returnAddress: governanceReturnAddress,
+  anchor: governanceAnchor,
+});
+
+const scriptProposal = (script: Script): GovernanceProposal => ({
+  action: parameterChangeAction(mintingPolicyToId(script)),
+  returnAddress: governanceReturnAddress,
+  anchor: governanceAnchor,
+});
 
 const makeTx = ({
   inputs = [makeUtxo("11")],
@@ -837,6 +885,794 @@ describe("context-dependent redeemers internal coverage", () => {
           presetWalletInputs: [],
         }),
     ).rejects.toThrow(/Stake:.*MISSING_REWARD_TYPE/);
+  });
+
+  test("propose adds a witnessless governance proposal with the default deposit", async () => {
+    const walletInput = makeRichUtxo("c0");
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      wallet: makeWallet([walletInput]),
+    })
+      .propose(infoProposal())
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const proposals = signBuilder.toTransaction().body().proposal_procedures();
+    expect(proposals).toBeDefined();
+    expect(proposals!.len()).toBe(1);
+    const proposal = proposals!.get(0);
+    expect(proposal.deposit()).toBe(
+      lucidConfig.protocolParameters.govActionDeposit,
+    );
+    expect(proposal.gov_action().kind()).toBe(CML.GovActionKind.InfoAction);
+    expect(proposal.reward_account().to_address().to_bech32(undefined)).toBe(
+      governanceReturnAddress,
+    );
+    expect(proposal.anchor().anchor_url().get()).toBe(governanceAnchor.url);
+    expect(
+      signBuilder.toTransaction().witness_set().redeemers(),
+    ).toBeUndefined();
+  });
+
+  test("propose builds all typed governance action variants", async () => {
+    const walletInput = makeRichUtxo("d0");
+    const actions: GovernanceAction[] = [
+      { ...parameterChangeAction("70".repeat(28)), policyHash: undefined },
+      {
+        type: "HardForkInitiation",
+        actionId: governanceActionId,
+        protocolVersion: { major: 11n, minor: 1n },
+      },
+      {
+        type: "TreasuryWithdrawals",
+        withdrawals: [
+          {
+            rewardAddress: governanceReturnAddress,
+            amount: 1_000_000n,
+          },
+        ],
+      },
+      { type: "NoConfidence", actionId: governanceActionId },
+      {
+        type: "UpdateCommittee",
+        actionId: governanceActionId,
+        remove: [{ type: "Key", hash: "71".repeat(28) }],
+        add: [
+          {
+            credential: { type: "Key", hash: "72".repeat(28) },
+            epoch: 12n,
+          },
+        ],
+        threshold: { numerator: 1n, denominator: 2n },
+      },
+      {
+        type: "NewConstitution",
+        actionId: governanceActionId,
+        constitution: { anchor: governanceAnchor },
+      },
+      { type: "InfoAction" },
+    ];
+
+    let builder = makeTxBuilder({
+      ...lucidConfig,
+      wallet: makeWallet([walletInput]),
+    });
+    for (const action of actions) {
+      builder = builder.propose({
+        action,
+        returnAddress: governanceReturnAddress,
+        anchor: governanceAnchor,
+      });
+    }
+
+    const signBuilder = await builder.complete({
+      localUPLCEval: false,
+      presetWalletInputs: [walletInput],
+    });
+
+    const proposals = signBuilder.toTransaction().body().proposal_procedures();
+    expect(proposals?.len()).toBe(actions.length);
+    expect(
+      Array.from({ length: proposals!.len() }, (_, index) =>
+        proposals!.get(index).gov_action().kind(),
+      ),
+    ).toEqual([
+      CML.GovActionKind.ParameterChangeAction,
+      CML.GovActionKind.HardForkInitiationAction,
+      CML.GovActionKind.TreasuryWithdrawalsAction,
+      CML.GovActionKind.NoConfidence,
+      CML.GovActionKind.UpdateCommittee,
+      CML.GovActionKind.NewConstitution,
+      CML.GovActionKind.InfoAction,
+    ]);
+    expect(
+      signBuilder.toTransaction().witness_set().redeemers(),
+    ).toBeUndefined();
+  });
+
+  test("propose rejects duplicate treasury withdrawal addresses", async () => {
+    const walletInput = makeRichUtxo("e5");
+    await expect(
+      makeTxBuilder({
+        ...lucidConfig,
+        wallet: makeWallet([walletInput]),
+      })
+        .propose({
+          action: {
+            type: "TreasuryWithdrawals",
+            withdrawals: [
+              {
+                rewardAddress: governanceReturnAddress,
+                amount: 1_000_000n,
+              },
+              {
+                rewardAddress: governanceReturnAddress,
+                amount: 2_000_000n,
+              },
+            ],
+          },
+          returnAddress: governanceReturnAddress,
+          anchor: governanceAnchor,
+        })
+        .complete({
+          localUPLCEval: false,
+          presetWalletInputs: [walletInput],
+        }),
+    ).rejects.toThrow(/Duplicate treasury withdrawal address/);
+  });
+
+  test("propose supports native-script governance action witnesses without Plutus redeemers", async () => {
+    const walletInput = makeRichUtxo("c1");
+    const nativeScript = scriptFromNative({
+      type: "sig",
+      keyHash: "67".repeat(28),
+    });
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.ProposeValidator(nativeScript)
+      .propose(scriptProposal(nativeScript))
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const tx = signBuilder.toTransaction();
+    const proposals = tx.body().proposal_procedures();
+    expect(proposals?.len()).toBe(1);
+    expect(proposals!.get(0).gov_action().script_hash()?.to_hex()).toBe(
+      mintingPolicyToId(nativeScript),
+    );
+    expect(tx.witness_set().redeemers()).toBeUndefined();
+  });
+
+  test("propose supports Plutus governance action witnesses with static redeemers", async () => {
+    const walletInput = makeRichUtxo("c2");
+    const evaluateTx = vi.fn<Provider["evaluateTx"]>(async () => [
+      {
+        redeemer_tag: "propose",
+        redeemer_index: 0,
+        ex_units: { mem: 620_000, steps: 720_000 },
+      },
+    ]);
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      provider: makeProvider(evaluateTx),
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.ProposeValidator(alwaysSucceedV3Script)
+      .propose(scriptProposal(alwaysSucceedV3Script), Data.to(42n))
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const tx = signBuilder.toTransaction();
+    const proposals = tx.body().proposal_procedures();
+    expect(proposals?.len()).toBe(1);
+    expect(proposals!.get(0).gov_action().kind()).toBe(
+      CML.GovActionKind.ParameterChangeAction,
+    );
+
+    const redeemers = tx.witness_set().redeemers();
+    expect(redeemers).toBeDefined();
+    const [redeemer] = canonicalRedeemerEntries(redeemers!);
+    expect(redeemer.tag).toBe("propose");
+    expect(redeemer.index).toBe(0n);
+    expect(redeemer.data.to_canonical_cbor_hex()).toBe(
+      redeemerData(42n).to_canonical_cbor_hex(),
+    );
+    expect(redeemer.exUnits.mem()).toBe(620_000n);
+    expect(redeemer.exUnits.steps()).toBe(720_000n);
+    expect(evaluateTx).toHaveBeenCalled();
+  });
+
+  test("context-dependent propose redeemers count all proposal procedures", async () => {
+    const walletInput = makeRichUtxo("c3");
+    const evaluateTx = vi.fn<Provider["evaluateTx"]>(async () => [
+      {
+        redeemer_tag: "propose",
+        redeemer_index: 1,
+        ex_units: { mem: 630_000, steps: 730_000 },
+      },
+    ]);
+    const stableRedeemer = vi.fn<BuildTxWithRedeemer>((ctx) => {
+      expect(ctx.ownPurpose.tag).toBe("propose");
+      expect(ctx.ownPurpose.index).toBe(1n);
+      expect(ctx.redeemerIndex(ctx.ownPurpose)).toBe(0n);
+      return Data.to(ctx.ownPurpose.index);
+    });
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      provider: makeProvider(evaluateTx),
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.ProposeValidator(alwaysSucceedV3Script)
+      .propose(infoProposal())
+      .propose(scriptProposal(alwaysSucceedV3Script), stableRedeemer)
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const proposals = signBuilder.toTransaction().body().proposal_procedures();
+    expect(proposals?.len()).toBe(2);
+    const redeemers = signBuilder.toTransaction().witness_set().redeemers();
+    expect(redeemers).toBeDefined();
+    const [redeemer] = canonicalRedeemerEntries(redeemers!);
+    expect(redeemer.tag).toBe("propose");
+    expect(redeemer.index).toBe(1n);
+    expect(redeemer.data.to_canonical_cbor_hex()).toBe(
+      redeemerData(1n).to_canonical_cbor_hex(),
+    );
+    expect(redeemer.exUnits.mem()).toBe(630_000n);
+    expect(redeemer.exUnits.steps()).toBe(730_000n);
+    expect(stableRedeemer).toHaveBeenCalled();
+  });
+
+  test("propose context skips native governance witnesses before Plutus proposals", async () => {
+    const walletInput = makeRichUtxo("c6");
+    const nativeScript = scriptFromNative({
+      type: "sig",
+      keyHash: "6c".repeat(28),
+    });
+    const evaluateTx = vi.fn<Provider["evaluateTx"]>(async () => [
+      {
+        redeemer_tag: "propose",
+        redeemer_index: 1,
+        ex_units: { mem: 631_000, steps: 731_000 },
+      },
+    ]);
+    const stableRedeemer = vi.fn<BuildTxWithRedeemer>((ctx) => {
+      expect(ctx.ownPurpose.tag).toBe("propose");
+      expect(ctx.ownPurpose.index).toBe(1n);
+      return Data.to(77n);
+    });
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      provider: makeProvider(evaluateTx),
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.ProposeValidator(nativeScript)
+      .attach.ProposeValidator(alwaysSucceedV3Script)
+      .propose(scriptProposal(nativeScript))
+      .propose(scriptProposal(alwaysSucceedV3Script), stableRedeemer)
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const tx = signBuilder.toTransaction();
+    expect(tx.body().proposal_procedures()?.len()).toBe(2);
+    const [redeemer] = canonicalRedeemerEntries(tx.witness_set().redeemers()!);
+    expect(redeemer.tag).toBe("propose");
+    expect(redeemer.index).toBe(1n);
+    expect(redeemer.data.to_canonical_cbor_hex()).toBe(
+      redeemerData(77n).to_canonical_cbor_hex(),
+    );
+
+    const [context] = signBuilder.toScriptContexts();
+    expect(context.scriptContextScriptInfo).toHaveProperty("ProposingScript");
+    if (!("ProposingScript" in context.scriptContextScriptInfo)) {
+      throw new Error("Expected a proposing script context.");
+    }
+    const [index, proposal] = context.scriptContextScriptInfo.ProposingScript;
+    expect(index).toBe(1n);
+    expect(proposal.ppGovernanceAction).toHaveProperty("ParameterChange");
+    expect(stableRedeemer).toHaveBeenCalled();
+  });
+
+  test("propose preserves missing script and missing redeemer errors", async () => {
+    const missingScriptHash = "68".repeat(28);
+    const missingScriptProposal: GovernanceProposal = {
+      ...infoProposal(),
+      action: parameterChangeAction(missingScriptHash),
+    };
+
+    await expect(
+      makeTxBuilder({
+        ...lucidConfig,
+        wallet: makeWallet([]),
+      })
+        .propose(missingScriptProposal, Data.void())
+        .complete({
+          localUPLCEval: false,
+          presetWalletInputs: [],
+        }),
+    ).rejects.toThrow(
+      new RegExp(`MISSING_SCRIPT:.*script_hash: ${missingScriptHash}`),
+    );
+
+    await expect(
+      makeTxBuilder({
+        ...lucidConfig,
+        wallet: makeWallet([]),
+      })
+        .attach.ProposeValidator(alwaysSucceedV3Script)
+        .propose(scriptProposal(alwaysSucceedV3Script))
+        .complete({
+          localUPLCEval: false,
+          presetWalletInputs: [],
+        }),
+    ).rejects.toThrow(/GovernanceAction:.*MISSING_REDEEMER/);
+  });
+
+  test("governance Plutus witnesses reject PlutusV1 and PlutusV2", async () => {
+    const walletInput = makeRichUtxo("e1");
+    for (const type of ["PlutusV1", "PlutusV2"] as const) {
+      const legacyScript: Script = { ...alwaysSucceedScript, type };
+      const voter = {
+        type: "DRep" as const,
+        credential: {
+          type: "Script" as const,
+          hash: mintingPolicyToId(legacyScript),
+        },
+      };
+      await expect(
+        makeTxBuilder({
+          ...lucidConfig,
+          wallet: makeWallet([walletInput]),
+        })
+          .attach.VoteValidator(legacyScript)
+          .vote(voter, governanceActionId, "Yes", undefined, Data.void())
+          .complete({
+            localUPLCEval: false,
+            presetWalletInputs: [walletInput],
+          }),
+      ).rejects.toThrow(
+        /GovernanceAction:.*Governance voting scripts must use PlutusV3/,
+      );
+
+      await expect(
+        makeTxBuilder({
+          ...lucidConfig,
+          wallet: makeWallet([walletInput]),
+        })
+          .attach.ProposeValidator(legacyScript)
+          .propose(scriptProposal(legacyScript), Data.void())
+          .complete({
+            localUPLCEval: false,
+            presetWalletInputs: [walletInput],
+          }),
+      ).rejects.toThrow(
+        /GovernanceAction:.*Governance proposal scripts must use PlutusV3/,
+      );
+    }
+  });
+
+  test("native governance witnesses ignore delayed redeemer callbacks", async () => {
+    const walletInput = makeRichUtxo("e2");
+    const nativeScript = scriptFromNative({
+      type: "sig",
+      keyHash: "75".repeat(28),
+    });
+    const voter = {
+      type: "DRep" as const,
+      credential: {
+        type: "Script" as const,
+        hash: mintingPolicyToId(nativeScript),
+      },
+    };
+    const delayedRedeemer = vi.fn<BuildTxWithRedeemer>(() => Data.void());
+
+    const proposalTx = await makeTxBuilder({
+      ...lucidConfig,
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.ProposeValidator(nativeScript)
+      .propose(scriptProposal(nativeScript), delayedRedeemer)
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+    const voteTx = await makeTxBuilder({
+      ...lucidConfig,
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.VoteValidator(nativeScript)
+      .vote(voter, governanceActionId, "Yes", undefined, delayedRedeemer)
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    expect(delayedRedeemer).not.toHaveBeenCalled();
+    expect(
+      proposalTx.toTransaction().witness_set().redeemers(),
+    ).toBeUndefined();
+    expect(voteTx.toTransaction().witness_set().redeemers()).toBeUndefined();
+  });
+
+  test("vote adds key DRep voting procedures without Plutus redeemers", async () => {
+    const walletInput = makeRichUtxo("c4");
+    const voter = {
+      type: "DRep" as const,
+      credential: { type: "Key" as const, hash: "69".repeat(28) },
+    };
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      wallet: makeWallet([walletInput]),
+    })
+      .vote(voter, governanceActionId, "Yes")
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const votingProcedures = signBuilder
+      .toTransaction()
+      .body()
+      .voting_procedures();
+    expect(votingProcedures).toBeDefined();
+    expect(votingProcedures!.len()).toBe(1);
+    const cmlVoter = votingProcedures!.keys().get(0);
+    expect(cmlVoter.as_d_rep_key_hash()?.to_hex()).toBe(voter.credential.hash);
+    const actionVotes = votingProcedures!.get(cmlVoter)!;
+    expect(actionVotes.len()).toBe(1);
+    expect(actionVotes.get(actionVotes.keys().get(0))!.vote()).toBe(
+      CML.Vote.Yes,
+    );
+    expect(
+      signBuilder.toTransaction().witness_set().redeemers(),
+    ).toBeUndefined();
+  });
+
+  test("vote builds committee and stake pool voter procedures without Plutus redeemers", async () => {
+    const walletInput = makeRichUtxo("d1");
+    const committeeVoter = {
+      type: "ConstitutionalCommittee" as const,
+      credential: { type: "Key" as const, hash: "73".repeat(28) },
+    };
+    const stakePoolVoter = {
+      type: "StakePool" as const,
+      hash: "74".repeat(28),
+    };
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      wallet: makeWallet([walletInput]),
+    })
+      .vote(committeeVoter, governanceActionId, "No")
+      .vote(stakePoolVoter, governanceActionId, "Abstain")
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const votingProcedures = signBuilder
+      .toTransaction()
+      .body()
+      .voting_procedures();
+    expect(votingProcedures?.len()).toBe(2);
+    const voters = Array.from({ length: votingProcedures!.len() }, (_, index) =>
+      votingProcedures!.keys().get(index).kind(),
+    );
+    expect(voters).toEqual([
+      CML.VoterKind.ConstitutionalCommitteeHotKeyHash,
+      CML.VoterKind.StakingPoolKeyHash,
+    ]);
+    expect(
+      signBuilder.toTransaction().witness_set().redeemers(),
+    ).toBeUndefined();
+  });
+
+  test("vote supports Plutus DRep witnesses and context-dependent redeemers", async () => {
+    const walletInput = makeRichUtxo("c5");
+    const voter = {
+      type: "DRep" as const,
+      credential: {
+        type: "Script" as const,
+        hash: mintingPolicyToId(alwaysSucceedV3Script),
+      },
+    };
+    const evaluateTx = vi.fn<Provider["evaluateTx"]>(async () => [
+      {
+        redeemer_tag: "vote",
+        redeemer_index: 0,
+        ex_units: { mem: 640_000, steps: 740_000 },
+      },
+    ]);
+    const stableRedeemer = vi.fn<BuildTxWithRedeemer>((ctx) => {
+      expect(ctx.ownPurpose.tag).toBe("vote");
+      expect(ctx.ownPurpose.index).toBe(0n);
+      return Data.to(ctx.ownPurpose.index + 9n);
+    });
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      provider: makeProvider(evaluateTx),
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.VoteValidator(alwaysSucceedV3Script)
+      .vote(voter, governanceActionId, "Abstain", undefined, stableRedeemer)
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const tx = signBuilder.toTransaction();
+    const votingProcedures = tx.body().voting_procedures();
+    expect(votingProcedures?.len()).toBe(1);
+    const redeemers = tx.witness_set().redeemers();
+    expect(redeemers).toBeDefined();
+    const [redeemer] = canonicalRedeemerEntries(redeemers!);
+    expect(redeemer.tag).toBe("vote");
+    expect(redeemer.index).toBe(0n);
+    expect(redeemer.data.to_canonical_cbor_hex()).toBe(
+      redeemerData(9n).to_canonical_cbor_hex(),
+    );
+    expect(redeemer.exUnits.mem()).toBe(640_000n);
+    expect(redeemer.exUnits.steps()).toBe(740_000n);
+    expect(stableRedeemer).toHaveBeenCalled();
+  });
+
+  test("vote context counts key voters before Plutus voting witnesses", async () => {
+    const walletInput = makeRichUtxo("c7");
+    const keyVoter = {
+      type: "DRep" as const,
+      credential: { type: "Key" as const, hash: "6d".repeat(28) },
+    };
+    const scriptHash = mintingPolicyToId(alwaysSucceedV3Script);
+    const scriptVoter = {
+      type: "DRep" as const,
+      credential: {
+        type: "Script" as const,
+        hash: scriptHash,
+      },
+    };
+    const evaluateTx = vi.fn<Provider["evaluateTx"]>(async () => [
+      {
+        redeemer_tag: "vote",
+        redeemer_index: 1,
+        ex_units: { mem: 641_000, steps: 741_000 },
+      },
+    ]);
+    const stableRedeemer = vi.fn<BuildTxWithRedeemer>((ctx) => {
+      expect(ctx.ownPurpose.tag).toBe("vote");
+      expect(ctx.ownPurpose.index).toBe(1n);
+      return Data.to(88n);
+    });
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      provider: makeProvider(evaluateTx),
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.VoteValidator(alwaysSucceedV3Script)
+      .vote(keyVoter, governanceActionId, "No")
+      .vote(scriptVoter, governanceActionId, "Yes", undefined, stableRedeemer)
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const tx = signBuilder.toTransaction();
+    expect(tx.body().voting_procedures()?.len()).toBe(2);
+    const [redeemer] = canonicalRedeemerEntries(tx.witness_set().redeemers()!);
+    expect(redeemer.tag).toBe("vote");
+    expect(redeemer.index).toBe(1n);
+    expect(redeemer.data.to_canonical_cbor_hex()).toBe(
+      redeemerData(88n).to_canonical_cbor_hex(),
+    );
+
+    const [context] = signBuilder.toScriptContexts();
+    expect(context.scriptContextScriptInfo).toHaveProperty("VotingScript");
+    if (!("VotingScript" in context.scriptContextScriptInfo)) {
+      throw new Error("Expected a voting script context.");
+    }
+    expect(context.scriptContextScriptInfo.VotingScript[0]).toEqual({
+      DRepVoter: [{ ScriptCredential: [scriptHash] }],
+    });
+    expect(stableRedeemer).toHaveBeenCalled();
+  });
+
+  test("vote context counts native voting witnesses before Plutus voters", async () => {
+    const walletInput = makeRichUtxo("c8");
+    const nativeScript = scriptFromNative({
+      type: "sig",
+      keyHash: "6e".repeat(28),
+    });
+    const nativeVoter = {
+      type: "DRep" as const,
+      credential: {
+        type: "Script" as const,
+        hash: mintingPolicyToId(nativeScript),
+      },
+    };
+    const scriptHash = mintingPolicyToId(alwaysSucceedV3Script);
+    const plutusVoter = {
+      type: "DRep" as const,
+      credential: {
+        type: "Script" as const,
+        hash: scriptHash,
+      },
+    };
+    const evaluateTx = vi.fn<Provider["evaluateTx"]>(async () => [
+      {
+        redeemer_tag: "vote",
+        redeemer_index: 1,
+        ex_units: { mem: 642_000, steps: 742_000 },
+      },
+    ]);
+    const stableRedeemer = vi.fn<BuildTxWithRedeemer>((ctx) => {
+      expect(ctx.ownPurpose.tag).toBe("vote");
+      expect(ctx.ownPurpose.index).toBe(1n);
+      return Data.to(99n);
+    });
+
+    const signBuilder = await makeTxBuilder({
+      ...lucidConfig,
+      provider: makeProvider(evaluateTx),
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.VoteValidator(nativeScript)
+      .attach.VoteValidator(alwaysSucceedV3Script)
+      .vote(nativeVoter, governanceActionId, "No")
+      .vote(plutusVoter, governanceActionId, "Yes", undefined, stableRedeemer)
+      .complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      });
+
+    const tx = signBuilder.toTransaction();
+    expect(tx.body().voting_procedures()?.len()).toBe(2);
+    const [redeemer] = canonicalRedeemerEntries(tx.witness_set().redeemers()!);
+    expect(redeemer.tag).toBe("vote");
+    expect(redeemer.index).toBe(1n);
+    expect(redeemer.data.to_canonical_cbor_hex()).toBe(
+      redeemerData(99n).to_canonical_cbor_hex(),
+    );
+
+    const [context] = signBuilder.toScriptContexts();
+    expect(context.scriptContextScriptInfo).toHaveProperty("VotingScript");
+    if (!("VotingScript" in context.scriptContextScriptInfo)) {
+      throw new Error("Expected a voting script context.");
+    }
+    expect(context.scriptContextScriptInfo.VotingScript[0]).toEqual({
+      DRepVoter: [{ ScriptCredential: [scriptHash] }],
+    });
+    expect(stableRedeemer).toHaveBeenCalled();
+  });
+
+  test("vote remaps Plutus witness order to canonical ledger voter indexes", async () => {
+    const walletInput = makeRichUtxo("e3");
+    const candidates = [alwaysSucceedV3Script, secondPlutusV3Script].map(
+      (script, index) => {
+        const hash = mintingPolicyToId(script);
+        return {
+          script,
+          hash,
+          voter: {
+            type: "DRep" as const,
+            credential: { type: "Script" as const, hash },
+          },
+          data: BigInt(index + 11),
+        };
+      },
+    );
+    const insertionOrder = [...candidates].sort((left, right) =>
+      right.hash.localeCompare(left.hash),
+    );
+    const evaluateTx = vi.fn<Provider["evaluateTx"]>(async (txHex) => {
+      const tx = CML.Transaction.from_cbor_hex(txHex);
+      const entries = canonicalRedeemerEntries(tx.witness_set().redeemers()!);
+      expect(entries.map(({ index }) => index)).toEqual([0n, 1n]);
+      return entries.map(({ index }) => ({
+        redeemer_tag: "vote" as const,
+        redeemer_index: Number(index),
+        ex_units: {
+          mem: 650_000 + Number(index),
+          steps: 750_000 + Number(index),
+        },
+      }));
+    });
+
+    let builder = makeTxBuilder({
+      ...lucidConfig,
+      provider: makeProvider(evaluateTx),
+      wallet: makeWallet([walletInput]),
+    })
+      .attach.VoteValidator(alwaysSucceedV3Script)
+      .attach.VoteValidator(secondPlutusV3Script);
+    insertionOrder.forEach((candidate, index) => {
+      builder = builder.vote(
+        candidate.voter,
+        { ...governanceActionId, index: BigInt(index) },
+        "Yes",
+        undefined,
+        Data.to(candidate.data),
+      );
+    });
+
+    const tx = (
+      await builder.complete({
+        localUPLCEval: false,
+        presetWalletInputs: [walletInput],
+      })
+    ).toTransaction();
+    const voters = CML.Transaction.from_cbor_bytes(tx.to_canonical_cbor_bytes())
+      .body()
+      .voting_procedures()!
+      .keys();
+    const canonicalHashes = Array.from({ length: voters.len() }, (_, index) =>
+      voters.get(index).script_hash()!.to_hex(),
+    );
+    expect(insertionOrder.map(({ hash }) => hash)).toEqual(
+      [...canonicalHashes].reverse(),
+    );
+
+    const entries = canonicalRedeemerEntries(tx.witness_set().redeemers()!);
+    for (const entry of entries) {
+      const voterHash = voters.get(Number(entry.index)).script_hash()!.to_hex();
+      const expected = candidates.find(({ hash }) => hash === voterHash)!;
+      expect(entry.data.to_canonical_cbor_hex()).toBe(
+        redeemerData(expected.data).to_canonical_cbor_hex(),
+      );
+      expect(entry.exUnits.mem()).toBe(650_000n + entry.index);
+      expect(entry.exUnits.steps()).toBe(750_000n + entry.index);
+    }
+    expect(evaluateTx).toHaveBeenCalled();
+  });
+
+  test("vote rejects duplicate Plutus redeemers for the same voter", async () => {
+    const walletInput = makeRichUtxo("e4");
+    const voter = {
+      type: "DRep" as const,
+      credential: {
+        type: "Script" as const,
+        hash: mintingPolicyToId(alwaysSucceedV3Script),
+      },
+    };
+    await expect(
+      makeTxBuilder({
+        ...lucidConfig,
+        wallet: makeWallet([walletInput]),
+      })
+        .attach.VoteValidator(alwaysSucceedV3Script)
+        .vote(voter, governanceActionId, "Yes", undefined, Data.to(1n))
+        .vote(
+          voter,
+          { ...governanceActionId, index: 1n },
+          "No",
+          undefined,
+          Data.to(2n),
+        )
+        .complete({
+          localUPLCEval: false,
+          presetWalletInputs: [walletInput],
+        }),
+    ).rejects.toThrow(
+      /GovernanceAction:.*Multiple Plutus voting procedures for the same voter/,
+    );
   });
 
   test("builder converges context-dependent certificate redeemers with provider evaluation", async () => {

--- a/packages/provider/src/internal/ogmios.ts
+++ b/packages/provider/src/internal/ogmios.ts
@@ -95,6 +95,43 @@ const TupleNumberFromString = S.compose(
   S.Array(S.NumberFromString),
 );
 
+const MaxReferenceScriptsSizeSchema = S.Struct({
+  bytes: S.Number,
+});
+
+export function normalizeProtocolParameters(
+  value: Record<string, unknown>,
+): Record<string, unknown> {
+  const legacy = value.maxReferenceScriptsSize;
+  const current = value.maxReferenceScriptsSizePerTransaction;
+
+  if (legacy === undefined && current === undefined) {
+    // Preserve the existing schema failure for a genuinely missing parameter.
+    return value;
+  }
+
+  const decode = S.decodeUnknownSync(MaxReferenceScriptsSizeSchema);
+  const legacyValue = legacy === undefined ? undefined : decode(legacy);
+  const currentValue = current === undefined ? undefined : decode(current);
+
+  if (
+    legacyValue !== undefined &&
+    currentValue !== undefined &&
+    legacyValue.bytes !== currentValue.bytes
+  ) {
+    throw new Error(
+      "Conflicting Ogmios protocol parameters: " +
+        "maxReferenceScriptsSize and " +
+        "maxReferenceScriptsSizePerTransaction differ",
+    );
+  }
+
+  return {
+    ...value,
+    maxReferenceScriptsSize: legacyValue ?? currentValue,
+  };
+}
+
 export const ProtocolParametersSchema = S.Struct({
   minFeeCoefficient: S.Number,
   minFeeReferenceScripts: S.Struct({
@@ -102,9 +139,7 @@ export const ProtocolParametersSchema = S.Struct({
     range: S.Number,
     multiplier: S.Number,
   }),
-  maxReferenceScriptsSize: S.Struct({
-    bytes: S.Number,
-  }),
+  maxReferenceScriptsSize: MaxReferenceScriptsSizeSchema,
   stakePoolVotingThresholds: S.Struct({
     noConfidence: TupleNumberFromString,
     constitutionalCommittee: S.Struct({

--- a/packages/provider/src/kupmios.ts
+++ b/packages/provider/src/kupmios.ts
@@ -91,7 +91,7 @@ export class Kupmios implements Provider {
       id: null,
     };
     const schema = Ogmios.JSONRPCResponseSchema(
-      Ogmios.ProtocolParametersSchema,
+      S.Record({ key: S.String, value: S.Unknown }),
     );
     const response = await pipe(
       HttpUtils.makePostAsJson(
@@ -106,7 +106,10 @@ export class Kupmios implements Provider {
       Effect.runPromise,
     );
     const result = Ogmios.getJSONRPCResult(response);
-    return toProtocolParameters(result);
+    const protocolParameters = S.decodeUnknownSync(
+      Ogmios.ProtocolParametersSchema,
+    )(Ogmios.normalizeProtocolParameters(result));
+    return toProtocolParameters(protocolParameters);
   }
 
   async getTreasury(): Promise<bigint> {

--- a/packages/provider/test/kupmios-ogmios.test.ts
+++ b/packages/provider/test/kupmios-ogmios.test.ts
@@ -1,11 +1,191 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { Kupmios } from "../src/kupmios.js";
 
+const baseProtocolParameters = {
+  minFeeCoefficient: 44,
+  minFeeReferenceScripts: {
+    base: 15,
+    range: 25_600,
+    multiplier: 1.2,
+  },
+  stakePoolVotingThresholds: {
+    noConfidence: "51/100",
+    constitutionalCommittee: {
+      default: "51/100",
+      stateOfNoConfidence: "51/100",
+    },
+    hardForkInitiation: "51/100",
+    protocolParametersUpdate: {
+      security: "51/100",
+    },
+  },
+  delegateRepresentativeVotingThresholds: {
+    noConfidence: "51/100",
+    constitutionalCommittee: {
+      default: "51/100",
+      stateOfNoConfidence: "51/100",
+    },
+    constitution: "51/100",
+    hardForkInitiation: "51/100",
+    protocolParametersUpdate: {
+      network: "51/100",
+      economic: "51/100",
+      technical: "51/100",
+      governance: "51/100",
+    },
+    treasuryWithdrawals: "51/100",
+  },
+  constitutionalCommitteeMinSize: 7,
+  constitutionalCommitteeMaxTermLength: 146,
+  governanceActionLifetime: 6,
+  governanceActionDeposit: { ada: { lovelace: 100_000_000_000 } },
+  delegateRepresentativeDeposit: { ada: { lovelace: 500_000_000 } },
+  delegateRepresentativeMaxIdleTime: 20,
+  minFeeConstant: { ada: { lovelace: 155_381 } },
+  maxBlockBodySize: { bytes: 90_112 },
+  maxBlockHeaderSize: { bytes: 1_100 },
+  maxTransactionSize: { bytes: 16_384 },
+  stakeCredentialDeposit: { ada: { lovelace: 2_000_000 } },
+  stakePoolDeposit: { ada: { lovelace: 500_000_000 } },
+  stakePoolRetirementEpochBound: 18,
+  desiredNumberOfStakePools: 500,
+  stakePoolPledgeInfluence: "3/10",
+  monetaryExpansion: "3/1000",
+  treasuryExpansion: "1/5",
+  minStakePoolCost: { ada: { lovelace: 170_000_000 } },
+  minUtxoDepositConstant: { ada: { lovelace: 0 } },
+  minUtxoDepositCoefficient: 4_310,
+  plutusCostModels: {
+    "plutus:v1": [1, 2],
+    "plutus:v2": [3, 4],
+    "plutus:v3": [5, 6],
+  },
+  scriptExecutionPrices: {
+    memory: "577/10000",
+    cpu: "721/10000000",
+  },
+  maxExecutionUnitsPerTransaction: {
+    memory: 14_000_000,
+    cpu: 10_000_000_000,
+  },
+  maxExecutionUnitsPerBlock: {
+    memory: 62_000_000,
+    cpu: 20_000_000_000,
+  },
+  maxValueSize: { bytes: 5_000 },
+  collateralPercentage: 150,
+  maxCollateralInputs: 3,
+  version: { major: 10, minor: 0 },
+};
+
+const protocolParametersResponse = (result: unknown) =>
+  new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      method: "queryLedgerState/protocolParameters",
+      result,
+      id: null,
+    }),
+    {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    },
+  );
+
+const queryProtocolParameters = async (result: unknown) => {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue(
+    protocolParametersResponse(result),
+  );
+  return new Kupmios(
+    "http://kupo.test",
+    "http://ogmios.test",
+  ).getProtocolParameters();
+};
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
 
 describe("Kupmios Ogmios JSON-RPC handling", () => {
+  test("accepts an Ogmios v6 max reference scripts size", async () => {
+    await expect(
+      queryProtocolParameters({
+        ...baseProtocolParameters,
+        maxReferenceScriptsSize: { bytes: 204_800 },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("accepts an Ogmios v7 max reference scripts size", async () => {
+    await expect(
+      queryProtocolParameters({
+        ...baseProtocolParameters,
+        maxReferenceScriptsSizePerTransaction: { bytes: 204_800 },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("accepts identical Ogmios v6 and v7 max reference scripts sizes", async () => {
+    await expect(
+      queryProtocolParameters({
+        ...baseProtocolParameters,
+        maxReferenceScriptsSize: { bytes: 204_800 },
+        maxReferenceScriptsSizePerTransaction: { bytes: 204_800 },
+      }),
+    ).resolves.toBeDefined();
+  });
+
+  test("rejects conflicting Ogmios v6 and v7 max reference scripts sizes", async () => {
+    await expect(
+      queryProtocolParameters({
+        ...baseProtocolParameters,
+        maxReferenceScriptsSize: { bytes: 204_800 },
+        maxReferenceScriptsSizePerTransaction: { bytes: 102_400 },
+      }),
+    ).rejects.toThrow(
+      "Conflicting Ogmios protocol parameters: maxReferenceScriptsSize and maxReferenceScriptsSizePerTransaction differ",
+    );
+  });
+
+  test("rejects a missing max reference scripts size through schema validation", async () => {
+    await expect(
+      queryProtocolParameters(baseProtocolParameters),
+    ).rejects.toThrow(/maxReferenceScriptsSize/);
+  });
+
+  test("rejects a malformed Ogmios v7 max reference scripts size", async () => {
+    await expect(
+      queryProtocolParameters({
+        ...baseProtocolParameters,
+        maxReferenceScriptsSizePerTransaction: { bytes: "oops" },
+      }),
+    ).rejects.toThrow(/bytes/);
+  });
+
+  test("converts equivalent Ogmios v6 and v7 protocol parameters identically", async () => {
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        protocolParametersResponse({
+          ...baseProtocolParameters,
+          maxReferenceScriptsSize: { bytes: 204_800 },
+        }),
+      )
+      .mockResolvedValueOnce(
+        protocolParametersResponse({
+          ...baseProtocolParameters,
+          maxReferenceScriptsSizePerTransaction: { bytes: 204_800 },
+        }),
+      );
+    const kupmios = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const v6 = await kupmios.getProtocolParameters();
+    const v7 = await kupmios.getProtocolParameters();
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(v7).toStrictEqual(v6);
+  });
+
   test("getDelegation accepts Ogmios reward account summaries", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(

--- a/packages/scalus-uplc/package.json
+++ b/packages/scalus-uplc/package.json
@@ -42,7 +42,7 @@
     "@lucid-evolution/core-types": "workspace:*",
     "@lucid-evolution/core-utils": "workspace:*",
     "cbor-x": "^1.6.0",
-    "scalus": "^0.18.0"
+    "scalus": "^0.18.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,8 +481,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
       scalus:
-        specifier: ^0.18.0
-        version: 0.18.0
+        specifier: ^0.18.1
+        version: 0.18.1
     devDependencies:
       '@types/node':
         specifier: ^20.12.8
@@ -5691,8 +5691,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  scalus@0.18.0:
-    resolution: {integrity: sha512-mW6wVAjcy2OZAH7lGvbMfOZtZqv8TPwIVPWoP6bUGnjZS6cyw9k4rL6yYiXKHxQWGHyPT/GTL0wcpPt8CwNj3g==}
+  scalus@0.18.1:
+    resolution: {integrity: sha512-E48QqNO/c/XT11Gl7TesUtcTEGFxSDKTG4IUIPv3eiYBpcfpcjtaKVKgEl8pbOs7ETfj5rtKbEPMmVjmf6fYbw==}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -12958,7 +12958,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  scalus@0.18.0: {}
+  scalus@0.18.1: {}
 
   scheduler@0.23.2:
     dependencies:


### PR DESCRIPTION
## Summary

- add first-class Conway governance `vote` and `propose` transaction-builder APIs
- support key, native-script, PlutusV3, static, and context-dependent governance witnesses
- translate CML governance witness ordinals to ledger proposal/voter indexes for evaluation and final serialization
- normalize Ogmios v6/v7 max-reference-script protocol parameter names inside the Kupmios provider
- update Scalus to 0.18.1 for PV11-aware evaluator behavior
- add patch changesets for Lucid/core types, provider, and Scalus

## Why

Ogmios v7 renamed `maxReferenceScriptsSize` to `maxReferenceScriptsSizePerTransaction`. Lucid's raw Ogmios schema required the old name even though the downstream conversion does not otherwise depend on that spelling, so live v7 protocol-parameter queries failed before conversion.

CML numbers voting/proposing redeemers by script-witness insertion order, while the Conway ledger indexes the full proposal collection and canonical voter map. Governance redeemers therefore need an identity-based translation at the evaluator and serialization boundaries.

## Compatibility and validation

- accepts Ogmios v6-only and v7-only protocol-parameter payloads
- accepts both names when values match and rejects conflicts explicitly
- preserves the existing schema failure when neither field is present
- rejects malformed v7 values
- preserves manual governance redeemer indexes when first-class builder tracking metadata is absent
- restricts Plutus governance witnesses to PlutusV3, matching Conway ledger support
- rejects duplicate Plutus voter purposes and duplicate treasury withdrawal addresses explicitly
- ignores delayed redeemer callbacks for native governance witnesses

Ogmios documents the field rename as a v7 breaking API change: https://github.com/CardanoSolutions/ogmios/releases/tag/v7.0.0

## Verification

- affected 12-package build graph: passed
- Lucid TypeScript lint: passed
- Scalus TypeScript lint: passed
- Scalus tests: 8 passed
- focused governance/redeemer tests: 36 passed
- focused Kupmios/Ogmios tests: 10 passed
- deterministic Lucid suite: 124 passed, 6 skipped
- deterministic provider suite: 29 passed, 42 skipped
- `git diff --check` and Prettier checks: passed
- live Docker preprod Ogmios v7/Kupo:
  - raw protocol response contains only `maxReferenceScriptsSizePerTransaction: { bytes: 204800 }`
  - v6/v7 conversion parity passed
  - successful submission/evaluation and v7 error-shape handling passed
  - overlapping supplied and chain-resolved UTxO evaluation passed
  - current live suite passed protocol/Kupo/delegation/failure checks and additional-UTxO samples 1, 2, and 4

One legacy live sample returned the same redeemer tags, indexes, and memory budgets but slightly different step budgets from its stored snapshot under the current node/cost model; no fixture was changed for that environment-dependent drift.
