### PR TITLE
test: retry Maestro rate limits

### DIFF
--- a/packages/lucid/test/onchain-preprod.test.ts
+++ b/packages/lucid/test/onchain-preprod.test.ts
@@ -25,7 +25,17 @@ import * as WalletEndpoint from "./specs/wallet.js";
 
 import * as DatumEndpoint from "./specs/datums.js";
 
-describe.sequential("Onchain testing", () => {
+const hasPreprodCredentials = Boolean(
+  process.env.VITE_BLOCKFROST_API_URL_PREPROD?.trim() &&
+    process.env.VITE_BLOCKFROST_KEY_PREPROD?.trim() &&
+    process.env.VITE_WALLET_SEED_2?.trim(),
+);
+
+const describeOnchainPreprod = hasPreprodCredentials
+  ? describe.sequential
+  : describe.skip;
+
+describeOnchainPreprod("Onchain testing", () => {
   test.skip("TxChain", async () => {
     const program = pipe(
       TxChain.depositFundsCollect,

--- a/packages/lucid/test/txHash.test.ts
+++ b/packages/lucid/test/txHash.test.ts
@@ -8,7 +8,15 @@ import {
 } from "../src/index.js";
 import { NETWORK } from "./specs/services.js";
 
-test("test txHash with defined provider", async () => {
+const hasBlockfrostCredentials = Boolean(
+  process.env.VITE_BLOCKFROST_API_URL_PREPROD?.trim() &&
+    process.env.VITE_BLOCKFROST_KEY_PREPROD?.trim() &&
+    process.env.VITE_WALLET_SEED?.trim(),
+);
+
+const testWithBlockfrost = hasBlockfrostCredentials ? test : test.skip;
+
+testWithBlockfrost("test txHash with defined provider", async () => {
   const projectId = process.env.VITE_BLOCKFROST_KEY_PREPROD;
   const lucid = await Lucid(
     new Blockfrost(process.env.VITE_BLOCKFROST_API_URL_PREPROD!, projectId),

--- a/packages/lucid/test/wallet.test.ts
+++ b/packages/lucid/test/wallet.test.ts
@@ -22,8 +22,17 @@ const loadConfig = Effect.gen(function* () {
 
 const NETWORK = "Preprod";
 
+const hasProviderCredentials = Boolean(
+  process.env.VITE_BLOCKFROST_API_URL_PREPROD?.trim() &&
+    process.env.VITE_BLOCKFROST_KEY_PREPROD?.trim() &&
+    process.env.VITE_WALLET_SEED_2?.trim() &&
+    process.env.VITE_MAESTRO_KEY?.trim(),
+);
+
+const testWithProviders = hasProviderCredentials ? test : test.skip;
+
 describe("Wallet", () => {
-  test("switchProvider", async () => {
+  testWithProviders("switchProvider", async () => {
     const program = Effect.gen(function* () {
       const [VITE_API_URL, VITE_BLOCKFROST_KEY, VITE_SEED, VITE_MAESTRO_KEY] =
         yield* loadConfig;
@@ -58,7 +67,7 @@ describe("Wallet", () => {
     assert.equal(seed.split(" ").length, 24);
     assert.notEqual(generateSeedPhrase(), seed);
   });
-  test("selectWallet.fromAddress", async () => {
+  testWithProviders("selectWallet.fromAddress", async () => {
     const program = Effect.gen(function* () {
       const [VITE_API_URL, VITE_BLOCKFROST_KEY, VITE_SEED, VITE_MAESTRO_KEY] =
         yield* loadConfig;
@@ -83,7 +92,7 @@ describe("Wallet", () => {
     await Effect.runPromise(program);
   });
 
-  test("selectWallet.fromPrivateKey", async () => {
+  testWithProviders("selectWallet.fromPrivateKey", async () => {
     const program = Effect.gen(function* () {
       const privateKey = CML.PrivateKey.generate_ed25519().to_bech32();
       const [VITE_API_URL, VITE_BLOCKFROST_KEY] = yield* loadConfig;

--- a/packages/provider/test/blockfrost.test.ts
+++ b/packages/provider/test/blockfrost.test.ts
@@ -4,15 +4,25 @@ import { Config, Effect } from "effect";
 import { Blockfrost } from "../src/blockfrost.js";
 import * as PreprodConstants from "./preprod-constants.js";
 
-export const blockfrost = await Effect.gen(function* () {
-  const BLOCKFROST_API_URL = yield* Config.string(
-    "VITE_BLOCKFROST_API_URL_PREPROD",
-  );
-  const BLOCKFROST_KEY = yield* Config.string("VITE_BLOCKFROST_KEY_PREPROD");
-  return new Blockfrost(BLOCKFROST_API_URL, BLOCKFROST_KEY);
-}).pipe(Effect.runPromise);
+const hasBlockfrostCredentials = Boolean(
+  process.env.VITE_BLOCKFROST_API_URL_PREPROD?.trim() &&
+    process.env.VITE_BLOCKFROST_KEY_PREPROD?.trim(),
+);
 
-describe("Blockfrost", async () => {
+export let blockfrost: Blockfrost;
+if (hasBlockfrostCredentials) {
+  blockfrost = await Effect.gen(function* () {
+    const BLOCKFROST_API_URL = yield* Config.string(
+      "VITE_BLOCKFROST_API_URL_PREPROD",
+    );
+    const BLOCKFROST_KEY = yield* Config.string("VITE_BLOCKFROST_KEY_PREPROD");
+    return new Blockfrost(BLOCKFROST_API_URL, BLOCKFROST_KEY);
+  }).pipe(Effect.runPromise);
+}
+
+const describeBlockfrost = hasBlockfrostCredentials ? describe : describe.skip;
+
+describeBlockfrost("Blockfrost", async () => {
   test("getProtocolParameters", async () => {
     const pp: ProtocolParameters = await blockfrost.getProtocolParameters();
     assert(pp);

--- a/packages/provider/test/maestro.test.ts
+++ b/packages/provider/test/maestro.test.ts
@@ -1,8 +1,9 @@
-import { assert, describe, expect, test } from "vitest";
+import { afterAll, assert, beforeAll, describe, expect, test } from "vitest";
 import { ProtocolParameters, UTxO } from "@lucid-evolution/core-types";
 import { Config, Effect } from "effect";
 import { Maestro } from "../src/index.js";
 import * as PreprodConstants from "./preprod-constants.js";
+import { with429Retry } from "./retrying-fetch.js";
 
 const hasMaestroKey = Boolean(process.env.VITE_MAESTRO_KEY_PREPROD?.trim());
 
@@ -17,6 +18,16 @@ if (hasMaestroKey) {
 const describeMaestro = hasMaestroKey ? describe : describe.skip;
 
 describeMaestro("maestro", async () => {
+  const fetchWithoutRetry = globalThis.fetch;
+
+  beforeAll(() => {
+    globalThis.fetch = with429Retry(fetchWithoutRetry);
+  });
+
+  afterAll(() => {
+    globalThis.fetch = fetchWithoutRetry;
+  });
+
   test("getProtocolParameters", async () => {
     const pp: ProtocolParameters = await maestro.getProtocolParameters();
     assert(pp);

--- a/packages/provider/test/retrying-fetch.test.ts
+++ b/packages/provider/test/retrying-fetch.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test, vi } from "vitest";
+import { with429Retry } from "./retrying-fetch.js";
+
+const asFetch = (implementation: () => Promise<Response>): typeof fetch =>
+  implementation as typeof fetch;
+
+describe("with429Retry", () => {
+  test("honors a Retry-After delay in seconds", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 429,
+          headers: { "Retry-After": "2" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("ok"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const response = await with429Retry(asFetch(fetchMock), { sleep })(
+      "https://example.test",
+    );
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(2_000);
+  });
+
+  test("honors a Retry-After HTTP date", async () => {
+    const now = Date.parse("2026-07-15T12:00:00.000Z");
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 429,
+          headers: {
+            "Retry-After": new Date(now + 3_000).toUTCString(),
+          },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("ok"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await with429Retry(asFetch(fetchMock), {
+      now: () => now,
+      sleep,
+    })("https://example.test");
+
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(3_000);
+  });
+
+  test("caps an excessive Retry-After delay", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(null, {
+          status: 429,
+          headers: { "Retry-After": "3600" },
+        }),
+      )
+      .mockResolvedValueOnce(new Response("ok"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await with429Retry(asFetch(fetchMock), {
+      maxDelayMs: 5_000,
+      sleep,
+    })("https://example.test");
+
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(5_000);
+  });
+
+  test("uses capped exponential delays without Retry-After", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 429 }))
+      .mockResolvedValueOnce(new Response(null, { status: 429 }))
+      .mockResolvedValueOnce(new Response("ok"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await with429Retry(asFetch(fetchMock), {
+      initialDelayMs: 2_000,
+      maxDelayMs: 3_000,
+      sleep,
+    })("https://example.test");
+
+    expect(sleep.mock.calls).toStrictEqual([[2_000], [3_000]]);
+  });
+
+  test("returns the final 429 response after the retry bound", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 429 }));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const response = await with429Retry(asFetch(fetchMock), {
+      maxRetries: 2,
+      sleep,
+    })("https://example.test");
+
+    expect(response.status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not retry non-429 responses", async () => {
+    const response = new Response(null, { status: 503 });
+    const fetchMock = vi.fn().mockResolvedValue(response);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      with429Retry(asFetch(fetchMock), { sleep })("https://example.test"),
+    ).resolves.toBe(response);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("https://example.test");
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  test("does not retry errors thrown by fetch", async () => {
+    const error = new Error("network failed");
+    const fetchMock = vi.fn().mockRejectedValue(error);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      with429Retry(asFetch(fetchMock), { sleep })("https://example.test"),
+    ).rejects.toBe(error);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("https://example.test");
+    expect(sleep).not.toHaveBeenCalled();
+  });
+});

--- a/packages/provider/test/retrying-fetch.ts
+++ b/packages/provider/test/retrying-fetch.ts
@@ -1,0 +1,53 @@
+export type Retry429Options = {
+  maxRetries?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  now?: () => number;
+  sleep?: (delayMs: number) => Promise<void>;
+};
+
+const defaultSleep = (delayMs: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, delayMs));
+
+const retryAfterDelayMs = (
+  retryAfter: string | null,
+  now: number,
+): number | undefined => {
+  if (retryAfter === null) return undefined;
+
+  const value = retryAfter.trim();
+  if (/^\d+(?:\.\d+)?$/.test(value)) {
+    return Number(value) * 1_000;
+  }
+
+  const retryAt = Date.parse(value);
+  return Number.isNaN(retryAt) ? undefined : Math.max(0, retryAt - now);
+};
+
+export const with429Retry = (
+  fetchImpl: typeof fetch,
+  {
+    maxRetries = 3,
+    initialDelayMs = 1_000,
+    maxDelayMs = 30_000,
+    now = Date.now,
+    sleep = defaultSleep,
+  }: Retry429Options = {},
+): typeof fetch => {
+  return async (...args: Parameters<typeof fetch>): Promise<Response> => {
+    for (let retries = 0; ; retries++) {
+      const response = await fetchImpl(...args);
+      if (response.status !== 429 || retries >= maxRetries) return response;
+
+      const requestedDelay = retryAfterDelayMs(
+        response.headers.get("Retry-After"),
+        now(),
+      );
+      const fallbackDelay = initialDelayMs * 2 ** retries;
+      const delayMs = Math.min(requestedDelay ?? fallbackDelay, maxDelayMs);
+
+      await response.body?.cancel().catch(() => undefined);
+      await sleep(delayMs);
+    }
+  };
+};


### PR DESCRIPTION
## Summary

- wrap fetch only for the credentialed Maestro provider integration suite
- retry HTTP 429 responses at most three times while honoring numeric and HTTP-date `Retry-After` values
- cap waits at 30 seconds and use capped exponential fallback delays when `Retry-After` is absent or malformed
- preserve immediate behavior for non-429 responses, network errors, and test assertion failures
- restore the original global fetch after the Maestro suite
- skip live Blockfrost and Lucid preprod tests when their required credentials are unavailable while keeping deterministic tests active

## Root cause

The generated Version Packages PR failed in the provider test task when Maestro rate-limited `getDatum` with HTTP 429. The existing live tests surfaced the response immediately even when Maestro supplied a retry window.

Failed run: https://github.com/Anastasia-Labs/lucid-evolution/actions/runs/29304106848/job/87014164280

This change is test-only and does not alter the published provider or application behavior.

The first two runs of this fork PR also exposed existing missing-secret failures. Fork workflows receive empty repository secrets, but the live Blockfrost provider suite and several Lucid preprod cases still attempted requests with an empty URL. The included guards require the exact credentials consumed by each network-dependent suite or case; deterministic provider, wallet, and transaction-hash coverage remains enabled.

## Validation

- focused retry suite: 7 passed
- complete provider suite: 48 passed, 43 credential-dependent tests skipped
- fork-equivalent provider suite with external secrets empty: 36 passed, 55 skipped
- fork-equivalent Lucid suite with external secrets empty: 124 passed, 120 skipped
- targeted strict TypeScript check for the provider changes: passed
- repository build: 14 tasks passed
- repository lint: 22 tasks passed
- repository format check: passed
- differential review: no actionable findings

The local environment did not contain a Maestro API key, so the live Maestro suite was skipped locally. Synthetic response coverage verifies both `Retry-After` forms, delay and retry bounds, fallback delays, non-429 pass-through, and thrown-error pass-through. The locally configured Blockfrost live suite still ran and passed after the credential gate was added.

No changeset is included because this modifies CI tests only.
