### PR TITLE
feat: harden provider correctness and add observation capabilities

### DIFF
--- a/.changeset/calm-ledgers-observe.md
+++ b/.changeset/calm-ledgers-observe.md
@@ -1,0 +1,15 @@
+---
+"@lucid-evolution/core-types": minor
+"@lucid-evolution/lucid": minor
+"@lucid-evolution/provider": minor
+"@lucid-evolution/wallet": minor
+---
+
+Add provider correctness and observation capabilities while preserving existing provider and wallet contracts.
+
+- Filter spent Emulator ledger entries from every public UTxO query and retain Emulator transaction status independently of output consumption.
+- Treat an empty wallet UTxO override as authoritative and add `clearUTxOOverride`.
+- Expose structured Kupmios and Ogmios errors with transport, HTTP, retry, operation, JSON-RPC, and cause metadata.
+- Add provider-neutral reward-account registration state, transaction status and cancellable confirmation waiting, and optional policy-ID UTxO lookup with a portable fallback.
+- Keep Kupmios unit queries exact for assets with an empty asset name instead of broadening them into policy queries.
+- Use validated per-Lucid-instance slot configuration throughout time conversion, transaction building, evaluation, signing, and script-context construction.

--- a/docs/pages/documentation/core-concepts/instantiate-evolution.mdx
+++ b/docs/pages/documentation/core-concepts/instantiate-evolution.mdx
@@ -5,3 +5,23 @@ Lucid Evolution is a transaction building framework for Cardano which provides f
 - Build and simulate transactions
 - Work with different Cardano networks (Mainnet, Preprod, Preview, or Custom networks)
 - Choose from multiple provider options for blockchain interaction
+
+## Custom network slot configuration
+
+Non-standard networks should supply their Shelley genesis slot mapping when the
+Lucid instance is created. The mapping is copied and kept per instance, so
+different Custom networks can safely coexist in one process.
+
+```typescript
+const lucid = await Lucid(provider, "Custom", {
+  slotConfig: {
+    zeroTime: 1710000000000, // Unix time in milliseconds at zeroSlot
+    zeroSlot: 0,
+    slotLength: 1000, // milliseconds
+  },
+});
+```
+
+`Emulator` instances derive this mapping automatically. Existing code that has
+initialized `SLOT_CONFIG_NETWORK.Custom` remains supported as a compatibility
+snapshot, but new Custom-network integrations should pass `slotConfig` directly.

--- a/docs/pages/documentation/core-concepts/provider/common-queries.mdx
+++ b/docs/pages/documentation/core-concepts/provider/common-queries.mdx
@@ -60,3 +60,54 @@ By abstracting away the provider calls, Evolution library provides different met
 
   </Tabs.Tab>
 </Tabs>
+
+## Provider capabilities
+
+New provider observations are optional on the `Provider` interface so existing
+third-party providers remain source-compatible. Lucid throws a
+`ProviderCapabilityError` when the configured provider does not implement a
+requested optional capability.
+
+### Policy queries
+
+Query all UTxOs at an address that contain any asset under a policy:
+
+```typescript
+const utxos = await lucid.utxosAtWithPolicy(address, policyId);
+```
+
+Kupmios uses Kupo's native `policy_id` filter. Other providers use a portable,
+exact policy-prefix fallback over `getUtxos`.
+
+### Reward-account registration
+
+Unlike `delegationAt`, reward-account state distinguishes an unregistered
+account from a registered, undelegated account with no rewards:
+
+```typescript
+const account = await lucid.rewardAccountAt(rewardAddress);
+// { registered: boolean, poolId: string | null, rewards: bigint }
+```
+
+`delegationAt` remains available for compatibility.
+
+### Transaction status and confirmation
+
+```typescript
+const status = await lucid.transactionStatus(txHash, { signal });
+
+const confirmation = await lucid.awaitTxConfirmation(txHash, {
+  checkInterval: 3000,
+  timeout: 120000,
+  minimumConfirmations: 2,
+  signal,
+});
+```
+
+Status can be `not_found`, `pending`, `failed`, or `confirmed`. Confirmation
+metadata contains only observations the provider can truthfully supply, such as
+block hash, height, slot, or actual block-confirmation count. The original
+boolean `awaitTx` method remains available for compatibility. A provider that
+does not expose an actual confirmation count can satisfy the default inclusion
+wait, but a `minimumConfirmations` value greater than one will continue polling
+until the caller's timeout.

--- a/docs/pages/documentation/core-concepts/provider/kupmios.mdx
+++ b/docs/pages/documentation/core-concepts/provider/kupmios.mdx
@@ -10,22 +10,22 @@ import { Lucid, Kupmios } from "@lucid-evolution/lucid";
 const lucid = await Lucid(
   new Kupmios(
     "http://localhost:1442", // Kupo endpoint
-    "http://localhost:1337" // Ogmios endpoint
+    "http://localhost:1337", // Ogmios endpoint
   ),
-  "Preview"
+  "Preview",
 );
 ```
 
 <Callout type="info">
   **If you have API keys**
 
-  ```typescript
-  const lucid = await Lucid(
+```typescript
+const lucid = await Lucid(
   new Kupmios("http://localhost:1442", "http://localhost:1337", {
     kupoHeader: { "priv-api-key": "<kupo-api-key>" }, // for example: "dmtr-api-key": "<kupo-api-key>"
     ogmiosHeader: { "priv-api-key": "<ogmios-api-key>" },
   }),
-  "Preview"
+  "Preview",
 );
 ```
 
@@ -35,3 +35,12 @@ const lucid = await Lucid(
   Kupmios is a mix of [Ogmios](https://ogmios.dev/) and
   [Kupo](https://cardanosolutions.github.io/kupo/).
 </Callout>
+
+Kupmios exposes structured `KupmiosError` and `OgmiosJsonRpcError` instances.
+Callers can inspect the operation, protocol, HTTP status, retryability,
+`retryAfterMs`, JSON-RPC code and data, and the original cause without parsing
+formatted error strings.
+
+Transaction confirmation queries intentionally do not use Kupo's `unspent`
+filter. A confirmed transaction remains confirmed when one of its outputs is
+spent shortly after inclusion.

--- a/docs/pages/documentation/core-concepts/wallet.mdx
+++ b/docs/pages/documentation/core-concepts/wallet.mdx
@@ -9,7 +9,7 @@ You can instantiate a wallet object from seed without binding it with a Lucid ob
 
 ```typescript
 import { generateSeedPhrase } from "@lucid-evolution/lucid";
- 
+
 const seedPhrase = generateSeedPhrase(); // BIP-39
 console.log(seedPhrase);
 ```
@@ -47,3 +47,18 @@ const usedKeyHashes: Array<KeyHash> = discoverOwnUsedTxKeyHashes(
 );
 console.log(usedKeyHashes); // ["KeyHash1", "KeyHash2"]
 ```
+
+## Authoritative UTxO overrides
+
+`overrideUTxOs` treats the supplied array as the complete wallet state,
+including an empty array. This is useful while chaining transactions or while a
+provider indexer is catching up.
+
+```typescript
+lucid.overrideUTxOs([]); // The wallet is authoritatively empty.
+
+// Resume querying the selected wallet's provider or wallet API.
+lucid.clearUTxOOverride();
+```
+
+Overrides remain active until replaced or explicitly cleared.

--- a/docs/pages/documentation/deep-dives/emulator.mdx
+++ b/docs/pages/documentation/deep-dives/emulator.mdx
@@ -84,6 +84,12 @@ const params = await emulator.getProtocolParameters();
 
 // Get datum by hash
 const datum = await emulator.getDatum(datumHash);
+
+// Distinguish unregistered and registered-but-undelegated accounts
+const rewardAccount = await emulator.getRewardAccount(rewardAddress);
+
+// Observe pending or confirmed transactions even after outputs are spent
+const status = await emulator.getTransactionStatus(txHash);
 ```
 
 </Steps>

--- a/packages/core-types/src/types.ts
+++ b/packages/core-types/src/types.ts
@@ -39,10 +39,25 @@ export interface Provider {
   getUtxoByUnit(unit: Unit): Promise<UTxO>;
   /** Query UTxOs by the output reference (tx hash and index). */
   getUtxosByOutRef(outRefs: Array<OutRef>): Promise<UTxO[]>;
+  /**
+   * Query UTxOs containing any asset under a policy. Providers may omit this
+   * optional fast-path capability.
+   */
+  getUtxosWithPolicy?(
+    addressOrCredential: Address | Credential,
+    policyId: PolicyId,
+  ): Promise<UTxO[]>;
   /** Query the current treasury amount in lovelace, when supported by the provider. */
   getTreasury?(): Promise<bigint>;
   getDelegation(rewardAddress: RewardAddress): Promise<Delegation>;
+  /** Query registration, rewards, and pool delegation when supported. */
+  getRewardAccount?(rewardAddress: RewardAddress): Promise<RewardAccountState>;
   getDatum(datumHash: DatumHash): Promise<Datum>;
+  /** Query the provider's current observation of a transaction. */
+  getTransactionStatus?(
+    txHash: TxHash,
+    options?: TransactionStatusOptions,
+  ): Promise<TransactionStatus>;
   awaitTx(txHash: TxHash, checkInterval?: number): Promise<boolean>;
   submitTx(tx: Transaction): Promise<TxHash>;
   evaluateTx(
@@ -285,6 +300,47 @@ export type Delegation = {
   rewards: Lovelace;
 };
 
+/** Provider-neutral reward-account state. */
+export type RewardAccountState = {
+  registered: boolean;
+  poolId: PoolId | null;
+  rewards: Lovelace;
+};
+
+/** Inclusion metadata known by a provider for a confirmed transaction. */
+export type TransactionConfirmation = {
+  txHash: TxHash;
+  blockHash?: string;
+  blockHeight?: number;
+  slot?: Slot;
+  /** Actual block confirmations. Providers must not substitute slot distance. */
+  confirmations?: number;
+};
+
+/** A provider's current observation of a transaction. */
+export type TransactionStatus =
+  | { status: "not_found"; txHash: TxHash }
+  | { status: "pending"; txHash: TxHash }
+  | { status: "failed"; txHash: TxHash; reason?: unknown }
+  | {
+      status: "confirmed";
+      txHash: TxHash;
+      confirmation: TransactionConfirmation;
+    };
+
+export type TransactionStatusOptions = {
+  signal?: AbortSignal;
+};
+
+export type AwaitTransactionOptions = TransactionStatusOptions & {
+  /** Polling interval in milliseconds. */
+  checkInterval?: number;
+  /** Maximum wait in milliseconds. */
+  timeout?: number;
+  /** Required actual block confirmations. */
+  minimumConfirmations?: number;
+};
+
 /**
  * A wallet that can be constructed from external data e.g utxos and an address.
  * It doesn't allow you to sign transactions/messages. This needs to be handled separately.
@@ -299,6 +355,8 @@ export type SignedMessage = { signature: string; key: string };
 
 export interface Wallet {
   overrideUTxOs(utxos: UTxO[]): void;
+  /** Clear a previously authoritative UTxO override. */
+  clearUTxOOverride?(): void;
   address(): Promise<Address>;
   rewardAddress(): Promise<RewardAddress | null>;
   getUtxos(): Promise<UTxO[]>;

--- a/packages/lucid/src/Errors.ts
+++ b/packages/lucid/src/Errors.ts
@@ -39,6 +39,19 @@ export class NullableError extends Data.TaggedError("NullableError")<{
   readonly message: string;
 }> {}
 
+export class ProviderCapabilityError extends Error {
+  readonly _tag = "ProviderCapabilityError";
+  readonly capability: string;
+
+  constructor(capability: string) {
+    super(
+      `The configured provider does not implement the optional ${capability} capability.`,
+    );
+    this.name = "ProviderCapabilityError";
+    this.capability = capability;
+  }
+}
+
 export class UnauthorizedNetwork extends Data.TaggedError(
   "UnauthorizedNetwork",
 )<{

--- a/packages/lucid/src/lucid-evolution/LucidEvolution.ts
+++ b/packages/lucid/src/lucid-evolution/LucidEvolution.ts
@@ -1,13 +1,21 @@
 import {
+  AwaitTransactionOptions,
   Credential,
   Delegation,
   EvaluatorAdapter,
   Network,
   OutRef,
+  PolicyId,
   PrivateKey,
   ProtocolParameters,
   Provider,
+  RewardAccountState,
+  Slot,
+  SlotConfig,
   Transaction,
+  TransactionConfirmation,
+  TransactionStatus,
+  TransactionStatusOptions,
   TxHash,
   Unit,
   UnixTime,
@@ -20,27 +28,37 @@ import { datumOf, metadataOf } from "./utils.js";
 import {
   createCostModels,
   PROTOCOL_PARAMETERS_DEFAULT,
-  unixTimeToSlot,
 } from "@lucid-evolution/utils";
 import * as TxBuilder from "../tx-builder/TxBuilder.js";
 import * as TxConfig from "../tx-builder/TxConfig.js";
 import * as TxSignBuilder from "../tx-sign-builder/TxSignBuilder.js";
-import { Data, SLOT_CONFIG_NETWORK } from "@lucid-evolution/plutus";
+import {
+  Data,
+  slotToBeginUnixTime,
+  unixTimeToEnclosingSlot,
+} from "@lucid-evolution/plutus";
 import {
   makeWalletFromAddress,
   makeWalletFromAPI,
   makeWalletFromPrivateKey,
   makeWalletFromSeed,
 } from "@lucid-evolution/wallet";
-import { Emulator } from "@lucid-evolution/provider";
-import { Effect, pipe, Data as _Data } from "effect";
-import { NullableError, UnauthorizedNetwork } from "../Errors.js";
-import { TimeoutExceptionTypeId } from "effect/Cause";
+import { isEmulatorProvider } from "@lucid-evolution/provider";
+import { resolveSlotConfig } from "./slotConfig.js";
+import { Effect, pipe } from "effect";
+import { NullableError } from "../Errors.js";
+import {
+  awaitTransactionConfirmation,
+  getRewardAccount,
+  getTransactionStatus,
+  getUtxosWithPolicy,
+} from "./providerCapabilities.js";
 
 export type LucidEvolution = {
   config: () => Partial<LucidConfig>;
   wallet: () => Wallet;
   overrideUTxOs: (utxos: UTxO[]) => void;
+  clearUTxOOverride: () => void;
   switchProvider: (provider: Provider) => Promise<void>;
   newTx: () => TxBuilder.TxBuilder;
   fromTx: (tx: Transaction) => TxSignBuilder.TxSignBuilder;
@@ -59,18 +77,32 @@ export type LucidEvolution = {
   };
   currentSlot: () => number;
   unixTimeToSlot: (unixTime: UnixTime) => number;
+  slotToUnixTime: (slot: Slot) => UnixTime;
   utxosAt: (addressOrCredential: string | Credential) => Promise<UTxO[]>;
   utxosAtWithUnit: (
     addressOrCredential: string | Credential,
     unit: string,
   ) => Promise<UTxO[]>;
+  utxosAtWithPolicy: (
+    addressOrCredential: string | Credential,
+    policyId: PolicyId,
+  ) => Promise<UTxO[]>;
   utxoByUnit: (unit: string) => Promise<UTxO>;
   utxosByOutRef: (outRefs: OutRef[]) => Promise<UTxO[]>;
   delegationAt: (rewardAddress: string) => Promise<Delegation>;
+  rewardAccountAt: (rewardAddress: string) => Promise<RewardAccountState>;
+  transactionStatus: (
+    txHash: TxHash,
+    options?: TransactionStatusOptions,
+  ) => Promise<TransactionStatus>;
   awaitTx: (
     txHash: string,
     checkInterval?: number | undefined,
   ) => Promise<boolean>;
+  awaitTxConfirmation: (
+    txHash: TxHash,
+    options?: AwaitTransactionOptions,
+  ) => Promise<TransactionConfirmation>;
   datumOf: <T extends Data>(utxo: UTxO, type?: T | undefined) => Promise<T>;
   metadataOf: <T = any>(unit: string) => Promise<T>;
 };
@@ -83,6 +115,11 @@ export type LucidConfig = {
   costModels: CML.CostModels;
   protocolParameters: ProtocolParameters;
   evaluator?: EvaluatorAdapter;
+  /**
+   * Per-instance slot-to-time mapping. Low-level callers that omit it retain
+   * the legacy network-table snapshot when constructing a transaction builder.
+   */
+  slotConfig?: SlotConfig;
 };
 
 export type LucidOptions = {
@@ -96,6 +133,8 @@ export type LucidOptions = {
    * Defaults to the built-in Aiken/WASM-backed evaluator.
    */
   evaluator?: EvaluatorAdapter;
+  /** Per-instance slot-to-time mapping. Required for uninitialized Custom networks. */
+  slotConfig?: SlotConfig;
 };
 
 //TODO: turn this to Effect
@@ -104,6 +143,7 @@ export const Lucid = async (
   network?: Network,
   options: LucidOptions = {},
 ): Promise<LucidEvolution> => {
+  const slotConfig = resolveSlotConfig(provider, network, options.slotConfig);
   const protocolParameters: ProtocolParameters | undefined =
     options.presetProtocolParameters ||
     (await provider?.getProtocolParameters());
@@ -122,31 +162,21 @@ export const Lucid = async (
         : undefined,
     protocolParameters,
     evaluator: options.evaluator,
+    slotConfig,
   };
-  if (config.provider && "slot" in config.provider) {
-    const emulator: Emulator = config.provider as Emulator;
-    Effect.gen(function* () {
-      const custom = yield* pipe(
-        validateNotNullableNetwork(network),
-        // Effect.filterOrFail(
-        //   (network) => network === "Custom",
-        //   () =>
-        //     new UnauthorizedNetwork({
-        //       message: `Expected Custom, received ${String(network)}`,
-        //     }),
-        // ),
-      );
-      SLOT_CONFIG_NETWORK[custom] = {
-        zeroTime: emulator.now(),
-        zeroSlot: 0,
-        slotLength: 1000,
-      };
-    }).pipe(Effect.runSync);
-  }
+  const configuredProvider = (): Provider => {
+    if (!config.provider) {
+      throw new NullableError({
+        message: "Provider is not set in Lucid instance",
+      });
+    }
+    return config.provider;
+  };
   return {
     config: () => config,
     wallet: () => config.wallet as Wallet,
     overrideUTxOs: (utxos: UTxO[]) => config.wallet?.overrideUTxOs(utxos),
+    clearUTxOOverride: () => config.wallet?.clearUTxOOverride?.(),
     switchProvider: async (provider: Provider) => {
       const protocolParam = await provider.getProtocolParameters();
       const costModels = createCostModels(protocolParam.costModels);
@@ -171,6 +201,10 @@ export const Lucid = async (
           config.protocolParameters,
           "protocolParameters are not set in Lucid instance",
         );
+        const slotConfig = yield* validateNotNullable(
+          config.slotConfig,
+          "slotConfig is not set in Lucid instance",
+        );
         return TxBuilder.makeTxBuilder({
           provider,
           network,
@@ -179,6 +213,7 @@ export const Lucid = async (
           txbuilderconfig,
           protocolParameters,
           evaluator: config.evaluator,
+          slotConfig,
         });
       }).pipe(Effect.runSync),
     fromTx: (tx: Transaction) =>
@@ -186,9 +221,7 @@ export const Lucid = async (
         config.wallet,
         CML.Transaction.from_cbor_hex(tx),
         {
-          slotConfig: config.network
-            ? SLOT_CONFIG_NETWORK[config.network]
-            : undefined,
+          slotConfig: config.slotConfig,
         },
       ),
     selectWallet: {
@@ -233,16 +266,28 @@ export const Lucid = async (
           );
         }).pipe(Effect.runSync),
     },
-    currentSlot: () =>
-      pipe(
-        validateNotNullableNetwork(config.network),
-        Effect.map((network) => unixTimeToSlot(network, Date.now())),
+    currentSlot: () => {
+      if (isEmulatorProvider(config.provider)) return config.provider.slot;
+      return pipe(
+        validateNotNullable(config.slotConfig, "slotConfig is not set"),
+        Effect.map((slotConfig) =>
+          unixTimeToEnclosingSlot(Date.now(), slotConfig),
+        ),
         Effect.runSync,
-      ),
+      );
+    },
     unixTimeToSlot: (unixTime: UnixTime) =>
       pipe(
-        validateNotNullableNetwork(config.network),
-        Effect.map((network) => unixTimeToSlot(network, unixTime)),
+        validateNotNullable(config.slotConfig, "slotConfig is not set"),
+        Effect.map((slotConfig) =>
+          unixTimeToEnclosingSlot(unixTime, slotConfig),
+        ),
+        Effect.runSync,
+      ),
+    slotToUnixTime: (slot: Slot) =>
+      pipe(
+        validateNotNullable(config.slotConfig, "slotConfig is not set"),
+        Effect.map((slotConfig) => slotToBeginUnixTime(slot, slotConfig)),
         Effect.runSync,
       ),
     utxosAt: (addressOrCredential: string | Credential) =>
@@ -263,6 +308,11 @@ export const Lucid = async (
         ),
         Effect.runPromise,
       ),
+    utxosAtWithPolicy: (
+      addressOrCredential: string | Credential,
+      policyId: PolicyId,
+    ) =>
+      getUtxosWithPolicy(configuredProvider(), addressOrCredential, policyId),
     utxoByUnit: (unit: Unit) =>
       pipe(
         validateNotNullableProvider(config.provider),
@@ -287,6 +337,10 @@ export const Lucid = async (
         ),
         Effect.runPromise,
       ),
+    rewardAccountAt: (rewardAddress: string) =>
+      getRewardAccount(configuredProvider(), rewardAddress),
+    transactionStatus: (txHash: TxHash, options?: TransactionStatusOptions) =>
+      getTransactionStatus(configuredProvider(), txHash, options),
     awaitTx: (txHash: TxHash, checkInterval?: number) =>
       pipe(
         validateNotNullableProvider(config.provider),
@@ -295,6 +349,8 @@ export const Lucid = async (
         ),
         Effect.runPromise,
       ),
+    awaitTxConfirmation: (txHash: TxHash, options?: AwaitTransactionOptions) =>
+      awaitTransactionConfirmation(configuredProvider(), txHash, options),
     datumOf: <T extends Data>(utxo: UTxO, type?: T | undefined) =>
       pipe(
         validateNotNullableProvider(config.provider),

--- a/packages/lucid/src/lucid-evolution/providerCapabilities.ts
+++ b/packages/lucid/src/lucid-evolution/providerCapabilities.ts
@@ -1,0 +1,190 @@
+import type {
+  Address,
+  AwaitTransactionOptions,
+  Credential,
+  PolicyId,
+  Provider,
+  RewardAccountState,
+  RewardAddress,
+  TransactionConfirmation,
+  TransactionStatus,
+  TransactionStatusOptions,
+  TxHash,
+  UTxO,
+} from "@lucid-evolution/core-types";
+import { ProviderCapabilityError } from "../Errors.js";
+
+const requireCapability = <T>(
+  capability: string,
+  implementation: T | undefined,
+): T => {
+  if (!implementation) throw new ProviderCapabilityError(capability);
+  return implementation;
+};
+
+const normalizedPolicyId = (policyId: PolicyId): PolicyId => {
+  if (!/^[0-9a-f]{56}$/i.test(policyId)) {
+    throw new TypeError("policyId must be a 56-character hexadecimal string.");
+  }
+  return policyId.toLowerCase();
+};
+
+export const getUtxosWithPolicy = async (
+  provider: Provider,
+  addressOrCredential: Address | Credential,
+  policyId: PolicyId,
+): Promise<UTxO[]> => {
+  const normalized = normalizedPolicyId(policyId);
+  if (provider.getUtxosWithPolicy) {
+    return provider.getUtxosWithPolicy(addressOrCredential, normalized);
+  }
+
+  const utxos = await provider.getUtxos(addressOrCredential);
+  return utxos.filter((utxo) =>
+    Object.entries(utxo.assets).some(
+      ([unit, amount]) =>
+        unit !== "lovelace" &&
+        amount !== 0n &&
+        unit.length >= 56 &&
+        unit.slice(0, 56).toLowerCase() === normalized,
+    ),
+  );
+};
+
+export const getRewardAccount = async (
+  provider: Provider,
+  rewardAddress: RewardAddress,
+): Promise<RewardAccountState> =>
+  await requireCapability(
+    "getRewardAccount",
+    provider.getRewardAccount?.bind(provider),
+  )(rewardAddress);
+
+export const getTransactionStatus = async (
+  provider: Provider,
+  txHash: TxHash,
+  options?: TransactionStatusOptions,
+): Promise<TransactionStatus> =>
+  await requireCapability(
+    "getTransactionStatus",
+    provider.getTransactionStatus?.bind(provider),
+  )(txHash, options);
+
+const abortError = (signal: AbortSignal): Error =>
+  signal.reason instanceof Error
+    ? signal.reason
+    : new DOMException("The operation was aborted.", "AbortError");
+
+const wait = (milliseconds: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(abortError(signal));
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, milliseconds);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(abortError(signal!));
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+
+const positiveNumber = (name: string, value: number): number => {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RangeError(`${name} must be a positive finite number.`);
+  }
+  return value;
+};
+
+export const awaitTransactionConfirmation = async (
+  provider: Provider,
+  txHash: TxHash,
+  options: AwaitTransactionOptions = {},
+): Promise<TransactionConfirmation> => {
+  const getStatus = requireCapability(
+    "getTransactionStatus",
+    provider.getTransactionStatus?.bind(provider),
+  );
+  const checkInterval = positiveNumber(
+    "checkInterval",
+    options.checkInterval ?? 3_000,
+  );
+  const timeout = positiveNumber("timeout", options.timeout ?? 160_000);
+  const minimumConfirmations = positiveNumber(
+    "minimumConfirmations",
+    options.minimumConfirmations ?? 1,
+  );
+  if (!Number.isSafeInteger(minimumConfirmations)) {
+    throw new RangeError(
+      "minimumConfirmations must be a positive safe integer.",
+    );
+  }
+
+  const timeoutError = () =>
+    new Error(`Timed out waiting for transaction ${txHash}.`);
+  const deadline = Date.now() + timeout;
+  while (true) {
+    if (options.signal?.aborted) throw abortError(options.signal);
+
+    const queryTimeRemaining = deadline - Date.now();
+    if (queryTimeRemaining <= 0) throw timeoutError();
+
+    const queryController = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    let onAbort: (() => void) | undefined;
+    const queryTimeout = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        const error = timeoutError();
+        queryController.abort(error);
+        reject(error);
+      }, queryTimeRemaining);
+    });
+    const queryAbort = new Promise<never>((_, reject) => {
+      if (!options.signal) return;
+      onAbort = () => {
+        const error = abortError(options.signal!);
+        queryController.abort(error);
+        reject(error);
+      };
+      options.signal.addEventListener("abort", onAbort, { once: true });
+    });
+
+    let result: TransactionStatus;
+    try {
+      result = await Promise.race([
+        getStatus(txHash, { signal: queryController.signal }),
+        queryTimeout,
+        queryAbort,
+      ]);
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId);
+      if (onAbort) options.signal?.removeEventListener("abort", onAbort);
+    }
+    if (result.status === "failed") {
+      throw new Error(`Transaction ${txHash} failed.`, {
+        cause: result.reason,
+      });
+    }
+    if (result.status === "confirmed") {
+      const confirmations = result.confirmation.confirmations;
+      if (
+        confirmations === undefined
+          ? minimumConfirmations === 1
+          : confirmations >= minimumConfirmations
+      ) {
+        return result.confirmation;
+      }
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      throw timeoutError();
+    }
+    await wait(Math.min(checkInterval, remaining), options.signal);
+  }
+};

--- a/packages/lucid/src/lucid-evolution/slotConfig.ts
+++ b/packages/lucid/src/lucid-evolution/slotConfig.ts
@@ -1,0 +1,49 @@
+import type {
+  Network,
+  Provider,
+  SlotConfig,
+} from "@lucid-evolution/core-types";
+import { SLOT_CONFIG_NETWORK } from "@lucid-evolution/plutus";
+import { isEmulatorProvider } from "@lucid-evolution/provider";
+
+const copyAndValidateSlotConfig = (slotConfig: SlotConfig): SlotConfig => {
+  if (
+    !Number.isSafeInteger(slotConfig.zeroTime) ||
+    !Number.isSafeInteger(slotConfig.zeroSlot) ||
+    slotConfig.zeroSlot < 0 ||
+    !Number.isSafeInteger(slotConfig.slotLength) ||
+    slotConfig.slotLength <= 0
+  ) {
+    throw new RangeError(
+      "Invalid slotConfig: zeroTime must be a safe integer, zeroSlot must be a non-negative safe integer, and slotLength must be a positive safe integer.",
+    );
+  }
+
+  return Object.freeze({ ...slotConfig });
+};
+
+export const resolveSlotConfig = (
+  provider: Provider | undefined,
+  network: Network | undefined,
+  explicit: SlotConfig | undefined,
+): SlotConfig | undefined => {
+  if (explicit) return copyAndValidateSlotConfig(explicit);
+
+  if (isEmulatorProvider(provider)) {
+    return copyAndValidateSlotConfig({
+      zeroTime: provider.now(),
+      zeroSlot: provider.slot,
+      slotLength: 1000,
+    });
+  }
+
+  if (!network) return undefined;
+
+  const staticConfig = SLOT_CONFIG_NETWORK[network];
+  if (network === "Custom" && staticConfig.slotLength <= 0) {
+    throw new Error(
+      "Custom network slot configuration is uninitialized. Pass Lucid(..., { slotConfig }) with the network genesis mapping.",
+    );
+  }
+  return copyAndValidateSlotConfig(staticConfig);
+};

--- a/packages/lucid/src/tx-builder/TxBuilder.ts
+++ b/packages/lucid/src/tx-builder/TxBuilder.ts
@@ -22,11 +22,12 @@ import {
   RewardAddress,
   Script,
   ScriptType,
+  SlotConfig,
   StakeKeyHash,
   TxOutput,
   UTxO,
 } from "@lucid-evolution/core-types";
-import { Data } from "@lucid-evolution/plutus";
+import { Data, SLOT_CONFIG_NETWORK } from "@lucid-evolution/plutus";
 import * as Collect from "./internal/Collect.js";
 import * as Read from "./internal/Read.js";
 import * as Attach from "./internal/Attach.js";
@@ -80,7 +81,7 @@ type CertificateRedeemer = Redeemer | BuildTxWithRedeemer;
 type GovernanceRedeemer = Redeemer | BuildTxWithRedeemer;
 
 export type TxBuilderConfig = {
-  readonly lucidConfig: LucidConfig;
+  readonly lucidConfig: LucidConfig & { readonly slotConfig: SlotConfig };
   readonly txBuilder: CML.TransactionBuilder;
   walletInputs: UTxO[];
   collectedInputs: UTxO[];
@@ -162,7 +163,14 @@ export const makeTxBuilderConfig = (
   lucidConfig: LucidConfig,
   source?: TxBuilderConfig,
 ): TxBuilderConfig => ({
-  lucidConfig,
+  lucidConfig: {
+    ...lucidConfig,
+    // Snapshot the legacy table only at this low-level compatibility boundary.
+    // Lucid instances always pass their own already-validated mapping.
+    slotConfig: Object.freeze({
+      ...(lucidConfig.slotConfig ?? SLOT_CONFIG_NETWORK[lucidConfig.network]),
+    }),
+  },
   txBuilder: CML.TransactionBuilder.new(lucidConfig.txbuilderconfig),
   walletInputs: [],
   collectedInputs: [],

--- a/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
+++ b/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
@@ -45,7 +45,6 @@ import {
   utxoToTransactionOutput,
   toCMLRedeemerTag,
 } from "@lucid-evolution/utils";
-import { SLOT_CONFIG_NETWORK } from "@lucid-evolution/plutus";
 import { collectFromUTxO } from "./Collect.js";
 import { TxConfig } from "./Service.js";
 import { isError } from "effect/Predicate";
@@ -326,7 +325,7 @@ const completeCurrentConfig = (
           ...config.collectedInputs,
           ...config.readInputs,
         ],
-        slotConfig: SLOT_CONFIG_NETWORK[config.lucidConfig.network],
+        slotConfig: config.lucidConfig.slotConfig,
       }),
     );
   }).pipe(Effect.catchAllDefect((cause) => new RunTimeError({ cause })));
@@ -1316,7 +1315,7 @@ const makeEvaluationContext = (
   config: TxBuilder.TxBuilderConfig,
 ): EvaluationContext => ({
   network: config.lucidConfig.network,
-  slotConfig: SLOT_CONFIG_NETWORK[config.lucidConfig.network],
+  slotConfig: config.lucidConfig.slotConfig,
   protocolParameters: config.lucidConfig.protocolParameters,
   costModels: config.lucidConfig.costModels,
 });

--- a/packages/lucid/src/tx-builder/internal/Interval.ts
+++ b/packages/lucid/src/tx-builder/internal/Interval.ts
@@ -1,18 +1,24 @@
 import { Effect } from "effect";
 import { UnixTime } from "@lucid-evolution/core-types";
 import * as TxBuilder from "../TxBuilder.js";
-import { unixTimeToSlot } from "@lucid-evolution/utils";
+import { unixTimeToEnclosingSlot } from "@lucid-evolution/plutus";
 import { TxConfig } from "./Service.js";
 
 export const validFrom = (unixTime: UnixTime) =>
   Effect.gen(function* () {
     const { config } = yield* TxConfig;
-    const slot = unixTimeToSlot(config.lucidConfig.network, unixTime);
+    const slot = unixTimeToEnclosingSlot(
+      unixTime,
+      config.lucidConfig.slotConfig,
+    );
     config.txBuilder.set_validity_start_interval(BigInt(slot));
   });
 export const validTo = (unixTime: UnixTime) =>
   Effect.gen(function* () {
     const { config } = yield* TxConfig;
-    const slot = unixTimeToSlot(config.lucidConfig.network, unixTime);
+    const slot = unixTimeToEnclosingSlot(
+      unixTime,
+      config.lucidConfig.slotConfig,
+    );
     config.txBuilder.set_ttl(BigInt(slot));
   });

--- a/packages/lucid/test/delayed-redeemer-errors.test.ts
+++ b/packages/lucid/test/delayed-redeemer-errors.test.ts
@@ -37,6 +37,7 @@ const lucidConfig = {
   txbuilderconfig: makeTxConfig(protocolParameters, costModels),
   costModels,
   protocolParameters,
+  slotConfig: { zeroTime: 0, zeroSlot: 0, slotLength: 1_000 },
 };
 
 const missingScriptHash = "11".repeat(28);

--- a/packages/lucid/test/emulator/builder/MintBuilder.ts
+++ b/packages/lucid/test/emulator/builder/MintBuilder.ts
@@ -5,7 +5,6 @@ import {
   getAddressDetails,
   mintingPolicyToId,
   scriptFromNative,
-  unixTimeToSlot,
 } from "@lucid-evolution/utils";
 import { fromText } from "@lucid-evolution/core-utils";
 import { Script } from "@lucid-evolution/core-types";
@@ -34,6 +33,7 @@ export const mintInSlotRange = (config: {
 export const makeMintingPolicy = (config: { address: string }) =>
   Effect.gen(function* () {
     const { emulator } = yield* EmulatorInstance;
+    const { user } = yield* User;
     const { paymentCredential } = getAddressDetails(config.address);
     const { hash } = yield* Effect.fromNullable(paymentCredential);
 
@@ -42,7 +42,7 @@ export const makeMintingPolicy = (config: { address: string }) =>
       scripts: [
         {
           type: "before",
-          slot: unixTimeToSlot("Custom", emulator.now() + 360000),
+          slot: user.unixTimeToSlot(emulator.now() + 360000),
         },
         { type: "sig", keyHash: hash },
       ],

--- a/packages/lucid/test/emulator/service.ts
+++ b/packages/lucid/test/emulator/service.ts
@@ -4,7 +4,6 @@ import {
   scriptFromNative,
   stringify,
   toUnit,
-  unixTimeToSlot,
   validatorToAddress,
 } from "@lucid-evolution/utils";
 import { Effect, Context, Layer, pipe, Console } from "effect";
@@ -83,7 +82,7 @@ export const mintInSlotRange = Effect.gen(function* () {
     scripts: [
       {
         type: "before",
-        slot: unixTimeToSlot("Custom", emulator.now() + 360000),
+        slot: user.unixTimeToSlot(emulator.now() + 360000),
       },
       { type: "sig", keyHash: paymentCredential?.hash! },
     ],
@@ -287,7 +286,7 @@ export const composeMintTx = Effect.gen(function* ($) {
     scripts: [
       {
         type: "before",
-        slot: unixTimeToSlot("Custom", emulator.now() + 60000),
+        slot: user.unixTimeToSlot(emulator.now() + 60000),
       },
       { type: "sig", keyHash: paymentCredential?.hash! },
     ],
@@ -319,7 +318,7 @@ export const composeMintAndStake = Effect.gen(function* ($) {
     scripts: [
       {
         type: "before",
-        slot: unixTimeToSlot("Custom", emulator.now() + 60000),
+        slot: user.unixTimeToSlot(emulator.now() + 60000),
       },
       { type: "sig", keyHash: paymentCredential?.hash! },
     ],
@@ -368,7 +367,7 @@ export const multiSigner = Effect.gen(function* ($) {
     scripts: [
       {
         type: "before",
-        slot: unixTimeToSlot("Custom", emulator.now() + 90000000000000),
+        slot: user.unixTimeToSlot(emulator.now() + 90000000000000),
       },
       { type: "sig", keyHash: paymentCredential?.hash! },
       { type: "sig", keyHash: paymentCredential1?.hash! },

--- a/packages/lucid/test/evaluator-adapter.test.ts
+++ b/packages/lucid/test/evaluator-adapter.test.ts
@@ -75,6 +75,7 @@ const lucidConfig = (provider: Provider, wallet: Wallet) => ({
   txbuilderconfig: makeTxConfig(protocolParameters, costModels),
   costModels,
   protocolParameters,
+  slotConfig: { zeroTime: 0, zeroSlot: 0, slotLength: 1_000 },
 });
 
 const makeUtxo = (
@@ -150,5 +151,32 @@ describe("evaluator adapter selection", () => {
       expect.arrayContaining([outRefKey(scriptUtxo), outRefKey(referenceUtxo)]),
     );
     expect(adapterEvaluate).not.toHaveBeenCalled();
+  });
+
+  test("passes the per-builder slot mapping to evaluator adapters", async () => {
+    const walletInput = makeUtxo("66");
+    const scriptUtxo = makeScriptUtxo("77");
+    const slotConfig = {
+      zeroTime: 1_700_000_000_000,
+      zeroSlot: 123_456,
+      slotLength: 250,
+    };
+    const adapterEvaluate = vi.fn<EvaluatorAdapter["evaluate"]>(async () => [
+      evalRedeemer(),
+    ]);
+
+    await makeTxBuilder({
+      ...lucidConfig(makeProvider(), makeWallet([walletInput])),
+      slotConfig,
+      evaluator: { name: "slot-aware", evaluate: adapterEvaluate },
+    })
+      .attach.SpendingValidator(alwaysSucceedScript)
+      .collectFrom([scriptUtxo], Data.void())
+      .complete({ presetWalletInputs: [walletInput] });
+
+    expect(adapterEvaluate).toHaveBeenCalled();
+    expect(adapterEvaluate.mock.calls.at(-1)?.[0].context.slotConfig).toEqual(
+      slotConfig,
+    );
   });
 });

--- a/packages/lucid/test/onchain-preprod.test.ts
+++ b/packages/lucid/test/onchain-preprod.test.ts
@@ -25,7 +25,14 @@ import * as WalletEndpoint from "./specs/wallet.js";
 
 import * as DatumEndpoint from "./specs/datums.js";
 
-describe.sequential("Onchain testing", () => {
+const onchainDescribe =
+  process.env.VITE_BLOCKFROST_API_URL_PREPROD &&
+  process.env.VITE_BLOCKFROST_KEY_PREPROD &&
+  process.env.VITE_WALLET_SEED_2
+    ? describe.sequential
+    : describe.skip;
+
+onchainDescribe("Onchain testing", () => {
   test.skip("TxChain", async () => {
     const program = pipe(
       TxChain.depositFundsCollect,

--- a/packages/lucid/test/provider-capabilities.test.ts
+++ b/packages/lucid/test/provider-capabilities.test.ts
@@ -1,0 +1,281 @@
+import type {
+  Provider,
+  TransactionStatus,
+  UTxO,
+} from "@lucid-evolution/core-types";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  Lucid,
+  PROTOCOL_PARAMETERS_DEFAULT,
+  ProviderCapabilityError,
+} from "../src/index.js";
+
+const address =
+  "addr_test1vzpwq95z3xyum8vqndgdd30p5y5wz7z6hqp5j3k6h8m83fs3s4l8w";
+const rewardAddress =
+  "stake_test17zt3vxfjx9pjnpnapa65lx375p2utwxmpc8afj053h0l3vgc8a3g3";
+const txHash = "a".repeat(64);
+const policyId = "b".repeat(56);
+
+const makeUtxo = (suffix: string, assets: UTxO["assets"]): UTxO => ({
+  txHash: suffix.repeat(64).slice(0, 64),
+  outputIndex: 0,
+  address,
+  assets,
+});
+
+const makeProvider = (overrides: Partial<Provider> = {}): Provider => ({
+  getProtocolParameters: async () => PROTOCOL_PARAMETERS_DEFAULT,
+  getUtxos: async () => [],
+  getUtxosWithUnit: async () => [],
+  getUtxoByUnit: async () => {
+    throw new Error("not implemented");
+  },
+  getUtxosByOutRef: async () => [],
+  getDelegation: async () => ({ poolId: null, rewards: 0n }),
+  getDatum: async () => "",
+  awaitTx: async () => true,
+  submitTx: async () => txHash,
+  evaluateTx: async () => [],
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("provider-neutral policy queries", () => {
+  test("fallback matches the exact 56-character policy prefix", async () => {
+    const match = makeUtxo("1", {
+      lovelace: 2_000_000n,
+      [`${policyId}01`]: 1n,
+      [`${policyId}02`]: 2n,
+    });
+    const zeroOnly = makeUtxo("2", {
+      lovelace: 2_000_000n,
+      [`${policyId}03`]: 0n,
+    });
+    const other = makeUtxo("3", {
+      lovelace: 2_000_000n,
+      [`${"c".repeat(56)}01`]: 1n,
+    });
+    const provider = makeProvider({
+      getUtxos: vi.fn(async () => [match, zeroOnly, other]),
+    });
+    const lucid = await Lucid(provider, "Preprod");
+
+    await expect(
+      lucid.utxosAtWithPolicy(address, policyId.toUpperCase()),
+    ).resolves.toEqual([match]);
+    expect(provider.getUtxos).toHaveBeenCalledWith(address);
+  });
+
+  test("uses a provider-native policy capability when available", async () => {
+    const match = makeUtxo("1", {
+      lovelace: 2_000_000n,
+      [`${policyId}01`]: 1n,
+    });
+    const native = vi.fn(async () => [match]);
+    const getUtxos = vi.fn(async () => []);
+    const lucid = await Lucid(
+      makeProvider({ getUtxosWithPolicy: native, getUtxos }),
+      "Preprod",
+    );
+
+    await expect(lucid.utxosAtWithPolicy(address, policyId)).resolves.toEqual([
+      match,
+    ]);
+    expect(native).toHaveBeenCalledWith(address, policyId);
+    expect(getUtxos).not.toHaveBeenCalled();
+  });
+
+  test("rejects malformed policy identifiers before querying", async () => {
+    const getUtxos = vi.fn(async () => []);
+    const lucid = await Lucid(makeProvider({ getUtxos }), "Preprod");
+
+    await expect(lucid.utxosAtWithPolicy(address, "abcd")).rejects.toThrow(
+      "56-character hexadecimal",
+    );
+    expect(getUtxos).not.toHaveBeenCalled();
+  });
+});
+
+describe("provider-neutral reward and transaction status", () => {
+  test("optional capability failures remain normal inspectable Errors", async () => {
+    const lucid = await Lucid(makeProvider(), "Preprod");
+
+    const rewardError = await lucid
+      .rewardAccountAt(rewardAddress)
+      .catch((error) => error);
+    const statusError = await lucid
+      .transactionStatus(txHash)
+      .catch((error) => error);
+
+    expect(rewardError).toBeInstanceOf(ProviderCapabilityError);
+    expect(rewardError).toMatchObject({ capability: "getRewardAccount" });
+    expect(statusError).toBeInstanceOf(ProviderCapabilityError);
+    expect(statusError).toMatchObject({ capability: "getTransactionStatus" });
+  });
+
+  test("forwards registration state and AbortSignal", async () => {
+    const controller = new AbortController();
+    const getTransactionStatus = vi.fn(
+      async (): Promise<TransactionStatus> => ({ status: "pending", txHash }),
+    );
+    const lucid = await Lucid(
+      makeProvider({
+        getRewardAccount: async () => ({
+          registered: true,
+          poolId: null,
+          rewards: 0n,
+        }),
+        getTransactionStatus,
+      }),
+      "Preprod",
+    );
+
+    await expect(lucid.rewardAccountAt(rewardAddress)).resolves.toEqual({
+      registered: true,
+      poolId: null,
+      rewards: 0n,
+    });
+    await expect(
+      lucid.transactionStatus(txHash, { signal: controller.signal }),
+    ).resolves.toEqual({ status: "pending", txHash });
+    expect(getTransactionStatus).toHaveBeenCalledWith(txHash, {
+      signal: controller.signal,
+    });
+  });
+
+  test("waits for the requested actual confirmation count", async () => {
+    vi.useFakeTimers();
+    const getTransactionStatus = vi
+      .fn<Provider["getTransactionStatus"]>()
+      .mockResolvedValueOnce({
+        status: "confirmed",
+        txHash,
+        confirmation: { txHash, confirmations: 1 },
+      })
+      .mockResolvedValueOnce({
+        status: "confirmed",
+        txHash,
+        confirmation: { txHash, confirmations: 2 },
+      });
+    const lucid = await Lucid(
+      makeProvider({ getTransactionStatus }),
+      "Preprod",
+    );
+
+    const result = lucid.awaitTxConfirmation(txHash, {
+      checkInterval: 10,
+      timeout: 100,
+      minimumConfirmations: 2,
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(result).resolves.toEqual({ txHash, confirmations: 2 });
+    expect(getTransactionStatus).toHaveBeenCalledTimes(2);
+  });
+
+  test("does not ignore a provider-reported zero confirmation count", async () => {
+    vi.useFakeTimers();
+    const getTransactionStatus = vi
+      .fn<Provider["getTransactionStatus"]>()
+      .mockResolvedValueOnce({
+        status: "confirmed",
+        txHash,
+        confirmation: { txHash, confirmations: 0 },
+      })
+      .mockResolvedValueOnce({
+        status: "confirmed",
+        txHash,
+        confirmation: { txHash, confirmations: 1 },
+      });
+    const lucid = await Lucid(
+      makeProvider({ getTransactionStatus }),
+      "Preprod",
+    );
+
+    const result = lucid.awaitTxConfirmation(txHash, {
+      checkInterval: 10,
+      timeout: 100,
+    });
+    await vi.advanceTimersByTimeAsync(10);
+
+    await expect(result).resolves.toEqual({ txHash, confirmations: 1 });
+    expect(getTransactionStatus).toHaveBeenCalledTimes(2);
+  });
+
+  test("honors cancellation before polling", async () => {
+    const getTransactionStatus = vi.fn<Provider["getTransactionStatus"]>();
+    const lucid = await Lucid(
+      makeProvider({ getTransactionStatus }),
+      "Preprod",
+    );
+    const controller = new AbortController();
+    const reason = new Error("caller cancelled");
+    controller.abort(reason);
+
+    await expect(
+      lucid.awaitTxConfirmation(txHash, { signal: controller.signal }),
+    ).rejects.toBe(reason);
+    expect(getTransactionStatus).not.toHaveBeenCalled();
+  });
+
+  test("cancels an in-progress wait and clears its polling timer", async () => {
+    vi.useFakeTimers();
+    const getTransactionStatus = vi.fn(
+      async (): Promise<TransactionStatus> => ({
+        status: "not_found",
+        txHash,
+      }),
+    );
+    const lucid = await Lucid(
+      makeProvider({ getTransactionStatus }),
+      "Preprod",
+    );
+    const controller = new AbortController();
+    const reason = new Error("stop waiting");
+
+    const result = lucid.awaitTxConfirmation(txHash, {
+      checkInterval: 1_000,
+      timeout: 10_000,
+      signal: controller.signal,
+    });
+    await Promise.resolve();
+    controller.abort(reason);
+
+    await expect(result).rejects.toBe(reason);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  test("enforces a caller-supplied timeout on an in-flight provider query", async () => {
+    vi.useFakeTimers();
+    let providerSignal: AbortSignal | undefined;
+    const getTransactionStatus = vi.fn(
+      async (
+        _txHash: string,
+        options?: { signal?: AbortSignal },
+      ): Promise<TransactionStatus> => {
+        providerSignal = options?.signal;
+        return new Promise(() => undefined);
+      },
+    );
+    const lucid = await Lucid(
+      makeProvider({ getTransactionStatus }),
+      "Preprod",
+    );
+
+    const result = lucid.awaitTxConfirmation(txHash, {
+      checkInterval: 10,
+      timeout: 25,
+    });
+    const assertion = expect(result).rejects.toThrow(
+      `Timed out waiting for transaction ${txHash}.`,
+    );
+    await vi.advanceTimersByTimeAsync(25);
+
+    await assertion;
+    expect(providerSignal?.aborted).toBe(true);
+  });
+});

--- a/packages/lucid/test/redeemer-builder-self-compat.test.ts
+++ b/packages/lucid/test/redeemer-builder-self-compat.test.ts
@@ -38,6 +38,7 @@ const lucidConfig = {
   txbuilderconfig: makeTxConfig(protocolParameters, costModels),
   costModels,
   protocolParameters,
+  slotConfig: { zeroTime: 0, zeroSlot: 0, slotLength: 1_000 },
 };
 
 const makeSelfRedeemerBuilder = (): SelfRedeemerBuilder => ({

--- a/packages/lucid/test/redeemer-context-internal.test.ts
+++ b/packages/lucid/test/redeemer-context-internal.test.ts
@@ -45,6 +45,7 @@ const lucidConfig = {
   txbuilderconfig: makeTxConfig(protocolParameters, costModels),
   costModels,
   protocolParameters,
+  slotConfig: { zeroTime: 0, zeroSlot: 0, slotLength: 1_000 },
 };
 
 const alwaysSucceedScript: Script = {

--- a/packages/lucid/test/redeemer-context.test.ts
+++ b/packages/lucid/test/redeemer-context.test.ts
@@ -34,6 +34,7 @@ const lucidConfig = {
   txbuilderconfig: makeTxConfig(protocolParameters, costModels),
   costModels,
   protocolParameters,
+  slotConfig: { zeroTime: 0, zeroSlot: 0, slotLength: 1_000 },
 };
 
 const redeemerData = (value: bigint): CML.PlutusData =>

--- a/packages/lucid/test/script-context.test.ts
+++ b/packages/lucid/test/script-context.test.ts
@@ -400,7 +400,14 @@ test("ScriptContextData matches Aiken script_context structure in an emulator tr
 test("TxSignBuilder produces a ScriptContext accepted by the Aiken structure checker", async () => {
   const account = generateEmulatorAccount({ lovelace: 75_000_000_000n });
   const emulator = new Emulator([account], PROTOCOL_PARAMETERS_DEFAULT);
-  const lucid = await Lucid(emulator, "Custom");
+  const slotConfig = {
+    zeroTime: emulator.now(),
+    zeroSlot: emulator.slot,
+    slotLength: 250,
+  };
+  const validFrom = slotConfig.zeroTime + 500;
+  const validTo = slotConfig.zeroTime + 1_000;
+  const lucid = await Lucid(emulator, "Custom", { slotConfig });
   lucid.selectWallet.fromSeed(account.seedPhrase);
 
   const mint = {
@@ -419,6 +426,8 @@ test("TxSignBuilder produces a ScriptContext accepted by the Aiken structure che
       Data.to(new Constr(0, [1n])),
     )
     .attach.MintingPolicy(mint)
+    .validFrom(validFrom)
+    .validTo(validTo)
     .complete();
   const scriptContext = signBuilder.toScriptContext({ Minting: [policyId] });
 
@@ -428,6 +437,22 @@ test("TxSignBuilder produces a ScriptContext accepted by the Aiken structure che
   });
   expect([...scriptContext.scriptContextTxInfo.txInfoRedeemers.keys()]).toEqual(
     [{ Minting: [policyId] }],
+  );
+  expect(
+    scriptContext.scriptContextTxInfo.txInfoValidRange.ivFrom.lowerBoundLimit,
+  ).toEqual({ Finite: [BigInt(validFrom)] });
+  expect(
+    scriptContext.scriptContextTxInfo.txInfoValidRange.ivTo.upperBoundLimit,
+  ).toEqual({ Finite: [BigInt(validTo)] });
+
+  const reconstructedContext = lucid
+    .fromTx(signBuilder.toCBOR())
+    .toScriptContext(
+      { Minting: [policyId] },
+      { resolvedInputs: await lucid.wallet().getUtxos() },
+    );
+  expect(reconstructedContext.scriptContextTxInfo.txInfoValidRange).toEqual(
+    scriptContext.scriptContextTxInfo.txInfoValidRange,
   );
 
   const checker = scripts.validators.find(
@@ -681,7 +706,7 @@ test("TxSignBuilder ScriptContexts match serialized ledger ScriptContexts for co
       signBuilder.toTransaction(),
       uniqueUtxos([...walletUtxos, ...scriptInputs, referenceInput]),
       costModels,
-      SLOT_CONFIG_NETWORK.Custom,
+      lucid.config().slotConfig!,
     );
     const actualCbor = extractTrace(failure, ECHO_CBO_PREFIX);
 

--- a/packages/lucid/test/slot-config.test.ts
+++ b/packages/lucid/test/slot-config.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  Emulator,
+  generateEmulatorAccount,
+  Lucid,
+  PROTOCOL_PARAMETERS_DEFAULT,
+  SLOT_CONFIG_NETWORK,
+} from "../src/index.js";
+
+const originalCustomSlotConfig = { ...SLOT_CONFIG_NETWORK.Custom };
+
+afterEach(() => {
+  SLOT_CONFIG_NETWORK.Custom = { ...originalCustomSlotConfig };
+});
+
+describe("per-instance slot configuration", () => {
+  test("keeps simultaneous Custom instances isolated and immutable", async () => {
+    const account = generateEmulatorAccount({ lovelace: 100_000_000n });
+    const emulator = new Emulator([account], PROTOCOL_PARAMETERS_DEFAULT);
+    const firstInput = { zeroTime: 1_000, zeroSlot: 10, slotLength: 100 };
+    const secondInput = { zeroTime: 5_000, zeroSlot: 70, slotLength: 250 };
+
+    const first = await Lucid(emulator, "Custom", { slotConfig: firstInput });
+    const second = await Lucid(emulator, "Custom", {
+      slotConfig: secondInput,
+    });
+    firstInput.zeroTime = 999_999;
+    secondInput.zeroSlot = 999_999;
+
+    expect(first.unixTimeToSlot(1_500)).toBe(15);
+    expect(second.unixTimeToSlot(5_500)).toBe(72);
+    expect(first.slotToUnixTime(15)).toBe(1_500);
+    expect(second.slotToUnixTime(72)).toBe(5_500);
+    expect(first.config().slotConfig).toEqual({
+      zeroTime: 1_000,
+      zeroSlot: 10,
+      slotLength: 100,
+    });
+    expect(Object.isFrozen(first.config().slotConfig)).toBe(true);
+    expect(SLOT_CONFIG_NETWORK.Custom).toEqual(originalCustomSlotConfig);
+  });
+
+  test("derives an Emulator mapping without mutating process-global state", async () => {
+    const account = generateEmulatorAccount({ lovelace: 100_000_000n });
+    const emulator = new Emulator([account], PROTOCOL_PARAMETERS_DEFAULT);
+    emulator.awaitSlot(7);
+
+    const lucid = await Lucid(emulator, "Custom");
+
+    expect(lucid.config().slotConfig).toEqual({
+      zeroTime: emulator.now(),
+      zeroSlot: 7,
+      slotLength: 1_000,
+    });
+    expect(lucid.unixTimeToSlot(emulator.now())).toBe(7);
+    emulator.awaitSlot(5);
+    expect(lucid.currentSlot()).toBe(12);
+    expect(SLOT_CONFIG_NETWORK.Custom).toEqual(originalCustomSlotConfig);
+  });
+
+  test("fails early for an uninitialized non-Emulator Custom network", async () => {
+    await expect(
+      Lucid(undefined, "Custom", {
+        presetProtocolParameters: PROTOCOL_PARAMETERS_DEFAULT,
+      }),
+    ).rejects.toThrow("Pass Lucid(..., { slotConfig })");
+  });
+
+  test("rejects mappings that cannot be translated safely", async () => {
+    const account = generateEmulatorAccount({ lovelace: 100_000_000n });
+    const emulator = new Emulator([account], PROTOCOL_PARAMETERS_DEFAULT);
+
+    await expect(
+      Lucid(emulator, "Custom", {
+        slotConfig: { zeroTime: 0.5, zeroSlot: 0, slotLength: 1_000 },
+      }),
+    ).rejects.toThrow("zeroTime must be a safe integer");
+    await expect(
+      Lucid(emulator, "Custom", {
+        slotConfig: { zeroTime: 0, zeroSlot: -1, slotLength: 1_000 },
+      }),
+    ).rejects.toThrow("zeroSlot must be a non-negative safe integer");
+    await expect(
+      Lucid(emulator, "Custom", {
+        slotConfig: { zeroTime: 0, zeroSlot: 0, slotLength: Infinity },
+      }),
+    ).rejects.toThrow("slotLength must be a positive safe integer");
+  });
+
+  test("snapshots an initialized legacy Custom mapping at creation", async () => {
+    SLOT_CONFIG_NETWORK.Custom = {
+      zeroTime: 20_000,
+      zeroSlot: 200,
+      slotLength: 500,
+    };
+    const lucid = await Lucid(undefined, "Custom", {
+      presetProtocolParameters: PROTOCOL_PARAMETERS_DEFAULT,
+    });
+
+    SLOT_CONFIG_NETWORK.Custom.zeroTime = 999_999;
+    SLOT_CONFIG_NETWORK.Custom.zeroSlot = 999_999;
+
+    expect(lucid.unixTimeToSlot(21_000)).toBe(202);
+    expect(lucid.slotToUnixTime(202)).toBe(21_000);
+    expect(lucid.config().slotConfig).toEqual({
+      zeroTime: 20_000,
+      zeroSlot: 200,
+      slotLength: 500,
+    });
+  });
+
+  test("uses the instance mapping for transaction validity intervals", async () => {
+    const account = generateEmulatorAccount({ lovelace: 100_000_000n });
+    const emulator = new Emulator([account], PROTOCOL_PARAMETERS_DEFAULT);
+    const lucid = await Lucid(emulator, "Custom", {
+      slotConfig: { zeroTime: 10_000, zeroSlot: 100, slotLength: 200 },
+    });
+    lucid.selectWallet.fromSeed(account.seedPhrase);
+
+    const signBuilder = await lucid
+      .newTx()
+      .pay.ToAddress(account.address, { lovelace: 2_000_000n })
+      .validFrom(11_000)
+      .validTo(12_000)
+      .complete();
+    const body = signBuilder.toTransaction().body();
+
+    expect(body.validity_interval_start()?.toString()).toBe("105");
+    expect(body.ttl()?.toString()).toBe("110");
+  });
+});

--- a/packages/lucid/test/txHash.test.ts
+++ b/packages/lucid/test/txHash.test.ts
@@ -8,7 +8,14 @@ import {
 } from "../src/index.js";
 import { NETWORK } from "./specs/services.js";
 
-test("test txHash with defined provider", async () => {
+const blockfrostTest =
+  process.env.VITE_BLOCKFROST_API_URL_PREPROD &&
+  process.env.VITE_BLOCKFROST_KEY_PREPROD &&
+  process.env.VITE_WALLET_SEED
+    ? test
+    : test.skip;
+
+blockfrostTest("test txHash with defined provider", async () => {
   const projectId = process.env.VITE_BLOCKFROST_KEY_PREPROD;
   const lucid = await Lucid(
     new Blockfrost(process.env.VITE_BLOCKFROST_API_URL_PREPROD!, projectId),

--- a/packages/lucid/test/wallet.test.ts
+++ b/packages/lucid/test/wallet.test.ts
@@ -22,8 +22,16 @@ const loadConfig = Effect.gen(function* () {
 
 const NETWORK = "Preprod";
 
+const liveProviderTest =
+  process.env.VITE_BLOCKFROST_API_URL_PREPROD &&
+  process.env.VITE_BLOCKFROST_KEY_PREPROD &&
+  process.env.VITE_WALLET_SEED_2 &&
+  process.env.VITE_MAESTRO_KEY
+    ? test
+    : test.skip;
+
 describe("Wallet", () => {
-  test("switchProvider", async () => {
+  liveProviderTest("switchProvider", async () => {
     const program = Effect.gen(function* () {
       const [VITE_API_URL, VITE_BLOCKFROST_KEY, VITE_SEED, VITE_MAESTRO_KEY] =
         yield* loadConfig;
@@ -58,7 +66,7 @@ describe("Wallet", () => {
     assert.equal(seed.split(" ").length, 24);
     assert.notEqual(generateSeedPhrase(), seed);
   });
-  test("selectWallet.fromAddress", async () => {
+  liveProviderTest("selectWallet.fromAddress", async () => {
     const program = Effect.gen(function* () {
       const [VITE_API_URL, VITE_BLOCKFROST_KEY, VITE_SEED, VITE_MAESTRO_KEY] =
         yield* loadConfig;
@@ -83,7 +91,7 @@ describe("Wallet", () => {
     await Effect.runPromise(program);
   });
 
-  test("selectWallet.fromPrivateKey", async () => {
+  liveProviderTest("selectWallet.fromPrivateKey", async () => {
     const program = Effect.gen(function* () {
       const privateKey = CML.PrivateKey.generate_ed25519().to_bech32();
       const [VITE_API_URL, VITE_BLOCKFROST_KEY] = yield* loadConfig;

--- a/packages/provider/src/blockfrost.ts
+++ b/packages/provider/src/blockfrost.ts
@@ -15,8 +15,11 @@ import {
   ProtocolParameters,
   Provider,
   RewardAddress,
+  RewardAccountState,
   Script,
   Transaction,
+  TransactionStatus,
+  TransactionStatusOptions,
   TxHash,
   Unit,
   UTxO,
@@ -197,17 +200,31 @@ export class Blockfrost implements Provider {
       );
   }
 
-  async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
-    const result = await fetch(`${this.url}/accounts/${rewardAddress}`, {
+  async getRewardAccount(
+    rewardAddress: RewardAddress,
+  ): Promise<RewardAccountState> {
+    const response = await fetch(`${this.url}/accounts/${rewardAddress}`, {
       headers: { project_id: this.projectId, lucid },
-    }).then((res) => res.json());
-    if (!result || result.error) {
-      return { poolId: null, rewards: 0n };
+    });
+    if (response.status === 404) {
+      return { registered: false, poolId: null, rewards: 0n };
     }
+    if (!response.ok) {
+      throw new Error(
+        `Could not fetch reward account from Blockfrost. Received status code: ${response.status}`,
+      );
+    }
+    const result = await response.json();
     return {
+      registered: result.active,
       poolId: result.pool_id || null,
       rewards: BigInt(result.withdrawable_amount),
     };
+  }
+
+  async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
+    const { poolId, rewards } = await this.getRewardAccount(rewardAddress);
+    return { poolId, rewards };
   }
 
   async getDatum(datumHash: DatumHash): Promise<Datum> {
@@ -235,6 +252,34 @@ export class Blockfrost implements Provider {
         }
       }, checkInterval);
     });
+  }
+
+  async getTransactionStatus(
+    txHash: TxHash,
+    options: TransactionStatusOptions = {},
+  ): Promise<TransactionStatus> {
+    const response = await fetch(`${this.url}/txs/${txHash}`, {
+      headers: { project_id: this.projectId, lucid },
+      signal: options.signal,
+    });
+    if (response.status === 404) return { status: "not_found", txHash };
+    if (!response.ok) {
+      throw new Error(
+        `Could not fetch transaction status from Blockfrost. Received status code: ${response.status}`,
+      );
+    }
+
+    const result = await response.json();
+    return {
+      status: "confirmed",
+      txHash,
+      confirmation: {
+        txHash,
+        blockHash: result.block,
+        blockHeight: result.block_height,
+        slot: result.slot,
+      },
+    };
   }
 
   async submitTx(tx: Transaction): Promise<TxHash> {

--- a/packages/provider/src/emulator.ts
+++ b/packages/provider/src/emulator.ts
@@ -14,8 +14,11 @@ import {
   ProtocolParameters,
   Provider,
   RewardAddress,
+  RewardAccountState,
   ScriptHash,
   Transaction,
+  TransactionStatus,
+  TransactionStatusOptions,
   TxHash,
   Unit,
   UnixTime,
@@ -32,6 +35,20 @@ import { walletFromSeed } from "@lucid-evolution/wallet";
 
 /** Concatentation of txHash + outputIndex */
 type FlatOutRef = string;
+
+const EMULATOR_PROVIDER_BRAND = Symbol.for(
+  "@lucid-evolution/provider/Emulator",
+);
+
+export const isEmulatorProvider = (
+  provider: Provider | undefined,
+): provider is Emulator =>
+  Boolean(
+    provider &&
+      (provider as Provider & { [EMULATOR_PROVIDER_BRAND]?: boolean })[
+        EMULATOR_PROVIDER_BRAND
+      ],
+  );
 
 export type EmulatorAccount = {
   seedPhrase: string;
@@ -76,6 +93,7 @@ export function generateEmulatorAccount(assets: Assets): EmulatorAccount {
 }
 
 export class Emulator implements Provider {
+  readonly [EMULATOR_PROVIDER_BRAND] = true;
   ledger: Record<FlatOutRef, { utxo: UTxO; spent: boolean }>;
   mempool: Record<FlatOutRef, { utxo: UTxO; spent: boolean }> = {};
   /**
@@ -92,6 +110,11 @@ export class Emulator implements Provider {
   protocolParameters: ProtocolParameters;
   datumTable: Record<DatumHash, Datum> = {};
   treasury: Lovelace;
+  transactionHistory: Record<
+    TxHash,
+    | { status: "pending" }
+    | { status: "confirmed"; blockHeight: number; slot: number }
+  > = {};
 
   constructor(
     accounts: EmulatorAccount[],
@@ -139,6 +162,18 @@ export class Emulator implements Provider {
     return this.time;
   }
 
+  private confirmPendingTransactions(blockHeight: number, slot: number) {
+    for (const [txHash, status] of Object.entries(this.transactionHistory)) {
+      if (status.status === "pending") {
+        this.transactionHistory[txHash] = {
+          status: "confirmed",
+          blockHeight,
+          slot,
+        };
+      }
+    }
+  }
+
   awaitSlot(length = 1) {
     this.slot += length;
     this.time += length * 1000;
@@ -146,6 +181,10 @@ export class Emulator implements Provider {
     this.blockHeight = Math.floor(this.slot / 20);
 
     if (this.blockHeight > currentHeight) {
+      this.confirmPendingTransactions(
+        currentHeight + 1,
+        (currentHeight + 1) * 20,
+      );
       for (const [outRef, { utxo, spent }] of Object.entries(this.mempool)) {
         this.ledger[outRef] = { utxo, spent };
       }
@@ -159,9 +198,15 @@ export class Emulator implements Provider {
   }
 
   awaitBlock(height = 1) {
+    const previousHeight = this.blockHeight;
+    const previousSlot = this.slot;
     this.blockHeight += height;
     this.slot += height * 20;
     this.time += height * 20 * 1000;
+
+    if (height > 0) {
+      this.confirmPendingTransactions(previousHeight + 1, previousSlot + 20);
+    }
 
     for (const [outRef, { utxo, spent }] of Object.entries(this.mempool)) {
       this.ledger[outRef] = { utxo, spent };
@@ -175,14 +220,19 @@ export class Emulator implements Provider {
   }
 
   getUtxos(addressOrCredential: Address | Credential): Promise<UTxO[]> {
-    const utxos: UTxO[] = Object.values(this.ledger).flatMap(({ utxo }) => {
-      if (typeof addressOrCredential === "string") {
-        return addressOrCredential === utxo.address ? utxo : [];
-      } else {
-        const { paymentCredential } = getAddressDetails(utxo.address);
-        return paymentCredential?.hash === addressOrCredential.hash ? utxo : [];
-      }
-    });
+    const utxos: UTxO[] = Object.values(this.ledger).flatMap(
+      ({ utxo, spent }) => {
+        if (spent) return [];
+        if (typeof addressOrCredential === "string") {
+          return addressOrCredential === utxo.address ? utxo : [];
+        } else {
+          const { paymentCredential } = getAddressDetails(utxo.address);
+          return paymentCredential?.hash === addressOrCredential.hash
+            ? utxo
+            : [];
+        }
+      },
+    );
 
     return Promise.resolve(utxos);
   }
@@ -203,34 +253,38 @@ export class Emulator implements Provider {
     addressOrCredential: Address | Credential,
     unit: Unit,
   ): Promise<UTxO[]> {
-    const utxos: UTxO[] = Object.values(this.ledger).flatMap(({ utxo }) => {
-      if (typeof addressOrCredential === "string") {
-        return addressOrCredential === utxo.address && utxo.assets[unit] > 0n
-          ? utxo
-          : [];
-      } else {
-        const { paymentCredential } = getAddressDetails(utxo.address);
-        return paymentCredential?.hash === addressOrCredential.hash &&
-          utxo.assets[unit] > 0n
-          ? utxo
-          : [];
-      }
-    });
+    const utxos: UTxO[] = Object.values(this.ledger).flatMap(
+      ({ utxo, spent }) => {
+        if (spent) return [];
+        if (typeof addressOrCredential === "string") {
+          return addressOrCredential === utxo.address && utxo.assets[unit] > 0n
+            ? utxo
+            : [];
+        } else {
+          const { paymentCredential } = getAddressDetails(utxo.address);
+          return paymentCredential?.hash === addressOrCredential.hash &&
+            utxo.assets[unit] > 0n
+            ? utxo
+            : [];
+        }
+      },
+    );
 
     return Promise.resolve(utxos);
   }
 
   getUtxosByOutRef(outRefs: OutRef[]): Promise<UTxO[]> {
     return Promise.resolve(
-      outRefs.flatMap(
-        (outRef) => this.ledger[outRef.txHash + outRef.outputIndex]?.utxo || [],
-      ),
+      outRefs.flatMap((outRef) => {
+        const entry = this.ledger[outRef.txHash + outRef.outputIndex];
+        return entry && !entry.spent ? entry.utxo : [];
+      }),
     );
   }
 
   getUtxoByUnit(unit: string): Promise<UTxO> {
-    const utxos: UTxO[] = Object.values(this.ledger).flatMap(({ utxo }) =>
-      utxo.assets[unit] > 0n ? utxo : [],
+    const utxos: UTxO[] = Object.values(this.ledger).flatMap(
+      ({ utxo, spent }) => (!spent && utxo.assets[unit] > 0n ? utxo : []),
     );
 
     if (utxos.length > 1) {
@@ -238,6 +292,15 @@ export class Emulator implements Provider {
     }
 
     return Promise.resolve(utxos[0]);
+  }
+
+  getRewardAccount(rewardAddress: RewardAddress): Promise<RewardAccountState> {
+    const account = this.chain[rewardAddress];
+    return Promise.resolve({
+      registered: account?.registeredStake ?? false,
+      poolId: account?.delegation.poolId ?? null,
+      rewards: account?.delegation.rewards ?? 0n,
+    });
   }
 
   getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
@@ -248,11 +311,40 @@ export class Emulator implements Provider {
   }
 
   awaitTx(txHash: string): Promise<boolean> {
-    if (this.mempool[txHash + 0]) {
+    if (this.transactionHistory[txHash]?.status === "pending") {
       this.awaitBlock();
       return Promise.resolve(true);
     }
     return Promise.resolve(true);
+  }
+
+  getTransactionStatus(
+    txHash: TxHash,
+    options: TransactionStatusOptions = {},
+  ): Promise<TransactionStatus> {
+    if (options.signal?.aborted) {
+      return Promise.reject(
+        options.signal.reason instanceof Error
+          ? options.signal.reason
+          : new DOMException("The operation was aborted.", "AbortError"),
+      );
+    }
+
+    const status = this.transactionHistory[txHash];
+    if (!status) return Promise.resolve({ status: "not_found", txHash });
+    if (status.status === "pending") {
+      return Promise.resolve({ status: "pending", txHash });
+    }
+    return Promise.resolve({
+      status: "confirmed",
+      txHash,
+      confirmation: {
+        txHash,
+        blockHeight: status.blockHeight,
+        slot: status.slot,
+        confirmations: this.blockHeight - status.blockHeight + 1,
+      },
+    });
   }
 
   /**
@@ -1136,6 +1228,8 @@ export class Emulator implements Provider {
     for (const [datumHash, datum] of Object.entries(datumTable)) {
       this.datumTable[datumHash] = datum;
     }
+
+    this.transactionHistory[txHash] = { status: "pending" };
 
     return Promise.resolve(txHash);
   }

--- a/packages/provider/src/errors.ts
+++ b/packages/provider/src/errors.ts
@@ -1,0 +1,168 @@
+export type ProviderTransportProtocol = "kupo" | "ogmios";
+
+export type ProviderErrorKind =
+  | "http"
+  | "timeout"
+  | "transport"
+  | "decode"
+  | "json_rpc"
+  | "aborted"
+  | "unknown";
+
+export type KupmiosErrorOptions = {
+  /** Optional only for compatibility with the former `{ cause }` constructor. */
+  protocol?: ProviderTransportProtocol;
+  /** Optional only for compatibility with the former `{ cause }` constructor. */
+  operation?: string;
+  cause?: unknown;
+  kind?: ProviderErrorKind;
+  status?: number;
+  retryable?: boolean;
+  retryAfterMs?: number;
+  message?: string;
+};
+
+const asRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined;
+
+const responseStatus = (cause: unknown): number | undefined => {
+  const response = asRecord(asRecord(cause)?.response);
+  return typeof response?.status === "number" ? response.status : undefined;
+};
+
+export const retryAfterHeaderToMs = (
+  value: string | undefined,
+): number | undefined => {
+  if (value === undefined) return undefined;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds)) return Math.max(0, seconds * 1000);
+
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp)
+    ? undefined
+    : Math.max(0, timestamp - Date.now());
+};
+
+const retryAfter = (cause: unknown): number | undefined => {
+  const response = asRecord(asRecord(cause)?.response);
+  const headers = asRecord(response?.headers);
+  const value = headers?.["retry-after"];
+  return retryAfterHeaderToMs(typeof value === "string" ? value : undefined);
+};
+
+const errorTag = (cause: unknown): string => {
+  const record = asRecord(cause);
+  return [record?._tag, record?.name, record?.reason]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+};
+
+const inferKind = (
+  cause: unknown,
+  status: number | undefined,
+): ProviderErrorKind => {
+  const tag = errorTag(cause);
+  if (tag.includes("timeout")) return "timeout";
+  if (tag.includes("parse") || tag.includes("decode")) return "decode";
+  if (status !== undefined) return "http";
+  if (tag.includes("request") || tag.includes("transport")) return "transport";
+  return "unknown";
+};
+
+const inferRetryable = (
+  kind: ProviderErrorKind,
+  status: number | undefined,
+): boolean =>
+  kind === "timeout" ||
+  kind === "transport" ||
+  status === 408 ||
+  status === 425 ||
+  status === 429 ||
+  (status !== undefined && status >= 500);
+
+export class KupmiosError extends Error {
+  readonly _tag: string = "KupmiosError";
+  readonly provider = "Kupmios" as const;
+  readonly protocol?: ProviderTransportProtocol;
+  readonly operation: string;
+  readonly kind: ProviderErrorKind;
+  readonly status?: number;
+  readonly retryable: boolean;
+  readonly retryAfterMs?: number;
+  override readonly cause?: unknown;
+
+  constructor(options: KupmiosErrorOptions) {
+    const status = options.status ?? responseStatus(options.cause);
+    const kind = options.kind ?? inferKind(options.cause, status);
+    const retryable = options.retryable ?? inferRetryable(kind, status);
+    const operation = options.operation ?? "unknown";
+    const statusSuffix = status === undefined ? "" : ` (HTTP ${status})`;
+    super(
+      options.message ??
+        `${options.protocol ?? "provider"} ${operation} failed${statusSuffix}`,
+      {
+        cause: options.cause,
+      },
+    );
+    this.name = "KupmiosError";
+    this.protocol = options.protocol;
+    this.operation = operation;
+    this.kind = kind;
+    this.status = status;
+    this.retryable = retryable;
+    this.retryAfterMs = options.retryAfterMs ?? retryAfter(options.cause);
+    this.cause = options.cause;
+  }
+}
+
+export type OgmiosJsonRpcErrorOptions = {
+  code: number;
+  message: string;
+  data?: unknown;
+  method?: string;
+  id: number | null;
+  operation?: string;
+  status?: number;
+  retryAfterMs?: number;
+  cause?: unknown;
+};
+
+export class OgmiosJsonRpcError extends KupmiosError {
+  override readonly _tag = "OgmiosJsonRpcError";
+  readonly code: number;
+  readonly data?: unknown;
+  readonly method?: string;
+  readonly id: number | null;
+
+  constructor(options: OgmiosJsonRpcErrorOptions) {
+    const dataSuffix =
+      options.data === undefined ? "" : `: ${JSON.stringify(options.data)}`;
+    super({
+      protocol: "ogmios",
+      operation: options.operation ?? options.method ?? "unknown",
+      kind: "json_rpc",
+      status: options.status,
+      retryAfterMs: options.retryAfterMs,
+      cause: options.cause,
+      message: `Ogmios JSON-RPC error ${options.code}: ${options.message}${dataSuffix}`,
+    });
+    this.name = "OgmiosJsonRpcError";
+    this.code = options.code;
+    this.data = options.data;
+    this.method = options.method;
+    this.id = options.id;
+  }
+}
+
+export const toKupmiosError = (
+  cause: unknown,
+  protocol: ProviderTransportProtocol,
+  operation: string,
+): KupmiosError =>
+  cause instanceof KupmiosError
+    ? cause
+    : new KupmiosError({ cause, protocol, operation });

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,3 +1,10 @@
+export {
+  OgmiosJsonRpcError,
+  type KupmiosErrorOptions,
+  type OgmiosJsonRpcErrorOptions,
+  type ProviderErrorKind,
+  type ProviderTransportProtocol,
+} from "./errors.js";
 export * from "./blockfrost.js";
 export * from "./kupmios.js";
 export * from "./emulator.js";

--- a/packages/provider/src/internal/HttpUtils.ts
+++ b/packages/provider/src/internal/HttpUtils.ts
@@ -74,6 +74,43 @@ export const makePostAsJson = <A, I, R>(
     Effect.scoped,
   );
 
+export const makePostAsJsonResponse = <A, I, R>(
+  url: string | URL,
+  data: unknown,
+  schema: Schema.Schema<A, I, R>,
+  headers: Record<string, string> | undefined,
+) =>
+  pipe(
+    HttpClientRequest.post(url),
+    headers ? HttpClientRequest.setHeaders(headers) : identity,
+    HttpClientRequest.bodyJson(data),
+    Effect.flatMap(HttpClient.execute),
+    Effect.flatMap((response) =>
+      pipe(
+        HttpClientResponse.schemaBodyJson(schema)(response),
+        Effect.map((body) => ({
+          body,
+          status: response.status,
+          headers: response.headers,
+        })),
+        Effect.catchAll((cause) =>
+          response.status >= 200 && response.status < 300
+            ? Effect.fail(cause)
+            : Effect.fail(
+                new HttpClientError.ResponseError({
+                  response,
+                  request: response.request,
+                  reason: "StatusCode",
+                  description:
+                    "non 2xx status code with an invalid JSON response",
+                }),
+              ),
+        ),
+      ),
+    ),
+    Effect.scoped,
+  );
+
 export const makePostAsUint8Array = <A, I, R>(
   url: string | URL,
   data: Uint8Array,

--- a/packages/provider/src/internal/koios.ts
+++ b/packages/provider/src/internal/koios.ts
@@ -257,8 +257,14 @@ export interface AssetAddress
 //NOTE: account_info schema is not complete
 // https://preprod.koios.rest/#post-/account_info
 export const AccountInfoSchema = S.Struct({
+  status: S.Literal("registered", "not registered"),
   delegated_pool: S.NullOr(S.String),
-  rewards_available: S.NumberFromString,
+  rewards_available: S.String,
+});
+
+export const TxStatusSchema = S.Struct({
+  tx_hash: S.String,
+  num_confirmations: S.NullOr(S.Number),
 });
 
 //NOTE: datum_info schema is not complete

--- a/packages/provider/src/internal/ogmios.ts
+++ b/packages/provider/src/internal/ogmios.ts
@@ -2,6 +2,11 @@ import { Schema as S } from "effect";
 import { applySingleCborEncoding, fromUnit } from "@lucid-evolution/utils";
 import { Record } from "effect";
 import * as CoreType from "@lucid-evolution/core-types";
+import {
+  KupmiosError,
+  OgmiosJsonRpcError,
+  retryAfterHeaderToMs,
+} from "../errors.js";
 
 export const JSONRPCSchema = <A, I, R>(schema: S.Schema<A, I, R>) =>
   S.Struct({
@@ -42,15 +47,35 @@ export const JSONRPCResponseSchema = <A, I, R>(schema: S.Schema<A, I, R>) =>
     identifier: "JSONRPCResponseSchema",
   });
 
-export const getJSONRPCResult = <A>(response: JSONRPCResponse<A>): A => {
+export const getJSONRPCResult = <A>(
+  response: JSONRPCResponse<A>,
+  operation?: string,
+  transport?: {
+    status: number;
+    headers: Readonly<Record<string, string>>;
+  },
+): A => {
   if ("error" in response) {
-    const data =
-      response.error.data === undefined
-        ? ""
-        : `: ${JSON.stringify(response.error.data)}`;
-    throw new Error(
-      `Ogmios JSON-RPC error ${response.error.code}: ${response.error.message}${data}`,
-    );
+    throw new OgmiosJsonRpcError({
+      code: response.error.code,
+      message: response.error.message,
+      data: response.error.data,
+      method: response.method,
+      id: response.id,
+      operation,
+      status: transport?.status,
+      retryAfterMs: retryAfterHeaderToMs(transport?.headers["retry-after"]),
+      cause: transport,
+    });
+  }
+  if (transport && (transport.status < 200 || transport.status >= 300)) {
+    throw new KupmiosError({
+      protocol: "ogmios",
+      operation: operation ?? response.method ?? "unknown",
+      status: transport.status,
+      retryAfterMs: retryAfterHeaderToMs(transport.headers["retry-after"]),
+      cause: transport,
+    });
   }
   return response.result;
 };
@@ -225,7 +250,7 @@ const LegacyDelegationSummarySchema = S.Struct({
 });
 
 const RewardAccountSummarySchema = S.Struct({
-  from: S.optional(S.Literal("key", "script")),
+  from: S.optional(S.Literal("key", "verificationKey", "script")),
   credential: S.optional(S.String),
   stakePool: S.optional(S.NullOr(S.Struct({ id: S.String }))),
   rewards: RewardAccountAdaSchema,

--- a/packages/provider/src/koios.ts
+++ b/packages/provider/src/koios.ts
@@ -9,7 +9,10 @@ import {
   ProtocolParameters,
   Provider,
   RewardAddress,
+  RewardAccountState,
   Transaction,
+  TransactionStatus,
+  TransactionStatusOptions,
   TxHash,
   Unit,
   UTxO,
@@ -260,7 +263,9 @@ export class Koios implements Provider {
     }
   }
 
-  async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
+  async getRewardAccount(
+    rewardAddress: RewardAddress,
+  ): Promise<RewardAccountState> {
     const body = {
       _stake_addresses: [rewardAddress],
     };
@@ -277,20 +282,26 @@ export class Koios implements Provider {
       ),
       // Allows for dependency injection and easier testing
       Effect.provide(FetchHttpClient.layer),
-      Effect.flatMap((result) =>
-        result.length === 0
-          ? Effect.fail("No Delegation Found by Reward Address")
-          : Effect.succeed(result[0]),
-      ),
       Effect.timeout(10_000),
       Effect.catchAllCause((cause) => new KoiosError({ cause })),
       Effect.runPromise,
     );
 
+    const account = result[0];
+    if (!account) {
+      return { registered: false, poolId: null, rewards: 0n };
+    }
+
     return {
-      poolId: result.delegated_pool || null,
-      rewards: BigInt(result.rewards_available),
+      registered: account.status === "registered",
+      poolId: account.delegated_pool || null,
+      rewards: BigInt(account.rewards_available),
     };
+  }
+
+  async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
+    const { poolId, rewards } = await this.getRewardAccount(rewardAddress);
+    return { poolId, rewards };
   }
 
   async getDatum(datumHash: DatumHash): Promise<Datum> {
@@ -346,6 +357,45 @@ export class Koios implements Provider {
     );
 
     return result;
+  }
+
+  async getTransactionStatus(
+    txHash: TxHash,
+    options: TransactionStatusOptions = {},
+  ): Promise<TransactionStatus> {
+    const url = `${this.baseUrl}/tx_status`;
+    const body = { _tx_hashes: [txHash] };
+    const bearerToken = this.token
+      ? { Authorization: `Bearer ${this.token}` }
+      : undefined;
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...bearerToken },
+      body: JSON.stringify(body),
+      signal: options.signal,
+    });
+    if (response.status === 404) return { status: "not_found", txHash };
+    if (!response.ok) {
+      throw new Error(
+        `Could not fetch transaction status from Koios. Received status code: ${response.status}`,
+      );
+    }
+    const result = S.decodeUnknownSync(S.Array(_Koios.TxStatusSchema))(
+      await response.json(),
+    );
+
+    const status = result[0];
+    if (!status || status.num_confirmations === null) {
+      return { status: "not_found", txHash };
+    }
+    return {
+      status: "confirmed",
+      txHash,
+      confirmation: {
+        txHash,
+        confirmations: status.num_confirmations,
+      },
+    };
   }
 
   async submitTx(tx: Transaction): Promise<TxHash> {

--- a/packages/provider/src/kupmios.ts
+++ b/packages/provider/src/kupmios.ts
@@ -7,30 +7,60 @@ import {
   Delegation,
   EvalRedeemer,
   OutRef,
+  PolicyId,
   ProtocolParameters,
   Provider,
   RewardAddress,
+  RewardAccountState,
   Script,
   Transaction,
+  TransactionStatus,
+  TransactionStatusOptions,
   TxHash,
   Unit,
   UTxO,
 } from "@lucid-evolution/core-types";
 import { applyDoubleCborEncoding, fromUnit } from "@lucid-evolution/utils";
 import { Schema as S } from "effect";
-import { Effect, pipe, Array as _Array, Schedule, Data } from "effect";
+import { Cause, Effect, Exit, pipe, Array as _Array, Schedule } from "effect";
 import * as Ogmios from "./internal/ogmios.js";
 import * as Kupo from "./internal/kupo.js";
 import * as HttpUtils from "./internal/HttpUtils.js";
 import { FetchHttpClient } from "@effect/platform";
+import { KupmiosError, toKupmiosError } from "./errors.js";
 
-export class KupmiosError extends Data.TaggedError("KupmiosError")<{
-  cause?: unknown;
-}> {
-  get message() {
-    return `${this.cause}`;
+export { KupmiosError } from "./errors.js";
+
+const catchProviderError =
+  (protocol: "kupo" | "ogmios", operation: string) =>
+  <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ): Effect.Effect<A, KupmiosError, R> =>
+    Effect.catchAll(effect, (cause) =>
+      Effect.fail(toKupmiosError(cause, protocol, operation)),
+    );
+
+const runProviderEffect = async <A>(
+  effect: Effect.Effect<A, unknown, never>,
+  protocol: "kupo" | "ogmios",
+  operation: string,
+  signal?: AbortSignal,
+): Promise<A> => {
+  const exit = await Effect.runPromiseExit(effect, { signal });
+  if (Exit.isSuccess(exit)) return exit.value;
+
+  if (signal?.aborted) {
+    throw new KupmiosError({
+      protocol,
+      operation,
+      kind: "aborted",
+      retryable: false,
+      cause: signal.reason ?? Cause.squash(exit.cause),
+    });
   }
-}
+
+  throw toKupmiosError(Cause.squash(exit.cause), protocol, operation);
+};
 
 /**
  * Provides support for interacting with both Kupo and Ogmios APIs.
@@ -93,19 +123,26 @@ export class Kupmios implements Provider {
     const schema = Ogmios.JSONRPCResponseSchema(
       S.Record({ key: S.String, value: S.Unknown }),
     );
-    const response = await pipe(
-      HttpUtils.makePostAsJson(
-        this.ogmiosUrl,
-        data,
-        schema,
-        this.headers?.ogmiosHeader,
+    const response = await runProviderEffect(
+      pipe(
+        HttpUtils.makePostAsJsonResponse(
+          this.ogmiosUrl,
+          data,
+          schema,
+          this.headers?.ogmiosHeader,
+        ),
+        Effect.timeout(10_000),
+        catchProviderError("ogmios", "queryLedgerState/protocolParameters"),
+        Effect.provide(FetchHttpClient.layer),
       ),
-      Effect.timeout(10_000),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.runPromise,
+      "ogmios",
+      "queryLedgerState/protocolParameters",
     );
-    const result = Ogmios.getJSONRPCResult(response);
+    const result = Ogmios.getJSONRPCResult(
+      response.body,
+      data.method,
+      response,
+    );
     const protocolParameters = S.decodeUnknownSync(
       Ogmios.ProtocolParametersSchema,
     )(Ogmios.normalizeProtocolParameters(result));
@@ -122,19 +159,26 @@ export class Kupmios implements Provider {
     const schema = Ogmios.JSONRPCResponseSchema(
       Ogmios.TreasuryAndReservesSchema,
     );
-    const response = await pipe(
-      HttpUtils.makePostAsJson(
-        this.ogmiosUrl,
-        data,
-        schema,
-        this.headers?.ogmiosHeader,
+    const response = await runProviderEffect(
+      pipe(
+        HttpUtils.makePostAsJsonResponse(
+          this.ogmiosUrl,
+          data,
+          schema,
+          this.headers?.ogmiosHeader,
+        ),
+        Effect.timeout(10_000),
+        catchProviderError("ogmios", "queryLedgerState/treasuryAndReserves"),
+        Effect.provide(FetchHttpClient.layer),
       ),
-      Effect.timeout(10_000),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.runPromise,
+      "ogmios",
+      "queryLedgerState/treasuryAndReserves",
     );
-    const result = Ogmios.getJSONRPCResult(response);
+    const result = Ogmios.getJSONRPCResult(
+      response.body,
+      data.method,
+      response,
+    );
     return Ogmios.lovelaceAmountToBigInt(result.treasury.ada.lovelace);
   }
 
@@ -145,15 +189,18 @@ export class Kupmios implements Provider {
       : addressOrCredential.hash;
     const pattern = `${this.kupoUrl}/matches/${queryPredicate}${isAddress ? "" : "/*"}?unspent`;
     const schema = S.Array(Kupo.UTxOSchema);
-    const utxos = await pipe(
-      HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-      Effect.flatMap((u) =>
-        kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
+    const utxos = await runProviderEffect(
+      pipe(
+        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
+        Effect.flatMap((u) =>
+          kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
+        ),
+        Effect.timeout(10_000),
+        catchProviderError("kupo", "getUtxos"),
+        Effect.provide(FetchHttpClient.layer),
       ),
-      Effect.timeout(10_000),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.runPromise,
+      "kupo",
+      "getUtxos",
     );
     return utxos;
   }
@@ -169,32 +216,72 @@ export class Kupmios implements Provider {
     const { policyId, assetName } = fromUnit(unit);
     const pattern = `${this.kupoUrl}/matches/${queryPredicate}${isAddress ? "" : "/*"}?unspent&policy_id=${policyId}${assetName ? `&asset_name=${assetName}` : ""}`;
     const schema = S.Array(Kupo.UTxOSchema);
-    const utxos = await pipe(
-      HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-      Effect.flatMap((u) =>
-        kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
+    const utxos = await runProviderEffect(
+      pipe(
+        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
+        Effect.flatMap((u) =>
+          kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
+        ),
+        Effect.timeout(10_000),
+        catchProviderError("kupo", "getUtxosWithUnit"),
+        Effect.provide(FetchHttpClient.layer),
       ),
-      Effect.timeout(10_000),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.runPromise,
+      "kupo",
+      "getUtxosWithUnit",
     );
-    return utxos;
+    // Kupo's asset_name query parameter cannot represent an empty asset name.
+    // Keep the Provider method's exact-unit contract when the policy filter is
+    // necessarily broader than the requested unit.
+    return utxos.filter((utxo) => (utxo.assets[unit] ?? 0n) > 0n);
+  }
+
+  async getUtxosWithPolicy(
+    addressOrCredential: Address | Credential,
+    policyId: PolicyId,
+  ): Promise<UTxO[]> {
+    if (!/^[0-9a-f]{56}$/i.test(policyId)) {
+      throw new TypeError(
+        "policyId must be a 56-character hexadecimal string.",
+      );
+    }
+    const normalizedPolicyId = policyId.toLowerCase();
+    const isAddress = typeof addressOrCredential === "string";
+    const queryPredicate = isAddress
+      ? addressOrCredential
+      : addressOrCredential.hash;
+    const pattern = `${this.kupoUrl}/matches/${queryPredicate}${isAddress ? "" : "/*"}?unspent&policy_id=${normalizedPolicyId}`;
+    const schema = S.Array(Kupo.UTxOSchema);
+    return runProviderEffect(
+      pipe(
+        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
+        Effect.flatMap((utxos) =>
+          kupmiosUtxosToUtxos(this.kupoUrl, utxos, this.headers?.kupoHeader),
+        ),
+        Effect.timeout(10_000),
+        catchProviderError("kupo", "getUtxosWithPolicy"),
+        Effect.provide(FetchHttpClient.layer),
+      ),
+      "kupo",
+      "getUtxosWithPolicy",
+    );
   }
 
   async getUtxoByUnit(unit: Unit): Promise<UTxO> {
     const { policyId, assetName } = fromUnit(unit);
-    const pattern = `${this.kupoUrl}/matches/${policyId}.${assetName ? `${assetName}` : "*"}?unspent`;
+    const pattern = `${this.kupoUrl}/matches/${policyId}.${assetName ?? ""}?unspent`;
     const schema = S.Array(Kupo.UTxOSchema);
-    const utxos = await pipe(
-      HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-      Effect.flatMap((u) =>
-        kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
+    const utxos = await runProviderEffect(
+      pipe(
+        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
+        Effect.flatMap((u) =>
+          kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
+        ),
+        Effect.timeout(10_000),
+        catchProviderError("kupo", "getUtxoByUnit"),
+        Effect.provide(FetchHttpClient.layer),
       ),
-      Effect.timeout(10_000),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.runPromise,
+      "kupo",
+      "getUtxoByUnit",
     );
     if (utxos.length === 0) {
       throw new Error("Unit not found.");
@@ -220,11 +307,13 @@ export class Kupmios implements Provider {
           kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
         ),
         Effect.timeout(10_000),
-        Effect.catchAll((cause) => new KupmiosError({ cause })),
+        catchProviderError("kupo", "getUtxosByOutRef"),
       ),
     );
-    const utxos: UTxO[][] = await Effect.runPromise(
+    const utxos: UTxO[][] = await runProviderEffect(
       pipe(program, Effect.provide(FetchHttpClient.layer)),
+      "kupo",
+      "getUtxosByOutRef",
     );
 
     return _Array
@@ -238,7 +327,9 @@ export class Kupmios implements Provider {
       );
   }
 
-  async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
+  async getRewardAccount(
+    rewardAddress: RewardAddress,
+  ): Promise<RewardAccountState> {
     const data = {
       jsonrpc: "2.0",
       method: "queryLedgerState/rewardAccountSummaries",
@@ -246,54 +337,106 @@ export class Kupmios implements Provider {
       id: null,
     };
     const schema = Ogmios.JSONRPCResponseSchema(Ogmios.Delegation);
-    const response = await pipe(
-      HttpUtils.makePostAsJson(
-        this.ogmiosUrl,
-        data,
-        schema,
-        this.headers?.ogmiosHeader,
+    const response = await runProviderEffect(
+      pipe(
+        HttpUtils.makePostAsJsonResponse(
+          this.ogmiosUrl,
+          data,
+          schema,
+          this.headers?.ogmiosHeader,
+        ),
+        Effect.provide(FetchHttpClient.layer),
+        Effect.timeout(10_000),
+        catchProviderError("ogmios", "queryLedgerState/rewardAccountSummaries"),
       ),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.timeout(10_000),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.runPromise,
+      "ogmios",
+      "queryLedgerState/rewardAccountSummaries",
     );
-    const result = Ogmios.getJSONRPCResult(response);
+    const result = Ogmios.getJSONRPCResult(
+      response.body,
+      data.method,
+      response,
+    );
 
-    return toDelegation(result);
+    return toRewardAccountState(result);
+  }
+
+  async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
+    const { poolId, rewards } = await this.getRewardAccount(rewardAddress);
+    return { poolId, rewards };
   }
 
   async getDatum(datumHash: DatumHash): Promise<Datum> {
     const pattern = `${this.kupoUrl}/datums/${datumHash}`;
     const schema = Kupo.DatumSchema;
-    const result = await pipe(
-      HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.timeout(10_000),
-      Effect.flatMap(Effect.fromNullable),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.runPromise,
+    const result = await runProviderEffect(
+      pipe(
+        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
+        Effect.provide(FetchHttpClient.layer),
+        Effect.timeout(10_000),
+        Effect.flatMap(Effect.fromNullable),
+        catchProviderError("kupo", "getDatum"),
+      ),
+      "kupo",
+      "getDatum",
     );
     return result.datum;
   }
 
+  async getTransactionStatus(
+    txHash: TxHash,
+    options: TransactionStatusOptions = {},
+  ): Promise<TransactionStatus> {
+    const pattern = `${this.kupoUrl}/matches/*@${txHash}`;
+    const schema = S.Array(Kupo.UTxOSchema).annotations({
+      identifier: "Array<KupmiosSchema.KupoUTxO>",
+    });
+    const matches = await runProviderEffect(
+      pipe(
+        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
+        Effect.timeout(10_000),
+        catchProviderError("kupo", "getTransactionStatus"),
+        Effect.provide(FetchHttpClient.layer),
+      ),
+      "kupo",
+      "getTransactionStatus",
+      options.signal,
+    );
+
+    if (matches.length === 0) return { status: "not_found", txHash };
+
+    const createdAt = matches[0].created_at;
+    return {
+      status: "confirmed",
+      txHash,
+      confirmation: {
+        txHash,
+        blockHash: createdAt.header_hash,
+        slot: createdAt.slot_no,
+      },
+    };
+  }
+
   async awaitTx(txHash: TxHash, checkInterval = 20000): Promise<boolean> {
-    const pattern = `${this.kupoUrl}/matches/*@${txHash}?unspent`;
+    const pattern = `${this.kupoUrl}/matches/*@${txHash}`;
     const schema = S.Array(Kupo.UTxOSchema).annotations({
       identifier: "Array<KupmiosSchema.KupoUTxO>",
     });
 
-    const result = await pipe(
-      HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.repeat({
-        schedule: Schedule.exponential(checkInterval),
-        until: (result) => result.length > 0,
-      }),
-      Effect.timeout(160_000),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.as(true),
-      Effect.runPromise,
+    const result = await runProviderEffect(
+      pipe(
+        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
+        Effect.provide(FetchHttpClient.layer),
+        Effect.repeat({
+          schedule: Schedule.exponential(checkInterval),
+          until: (result) => result.length > 0,
+        }),
+        Effect.timeout(160_000),
+        catchProviderError("kupo", "awaitTx"),
+        Effect.as(true),
+      ),
+      "kupo",
+      "awaitTx",
     );
     return result;
   }
@@ -314,19 +457,26 @@ export class Kupmios implements Provider {
         }),
       }),
     );
-    const response = await pipe(
-      HttpUtils.makePostAsJson(
-        this.ogmiosUrl,
-        data,
-        schema,
-        this.headers?.ogmiosHeader,
+    const response = await runProviderEffect(
+      pipe(
+        HttpUtils.makePostAsJsonResponse(
+          this.ogmiosUrl,
+          data,
+          schema,
+          this.headers?.ogmiosHeader,
+        ),
+        Effect.provide(FetchHttpClient.layer),
+        Effect.timeout(10_000),
+        catchProviderError("ogmios", "submitTransaction"),
       ),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.timeout(10_000),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.runPromise,
+      "ogmios",
+      "submitTransaction",
     );
-    const result = Ogmios.getJSONRPCResult(response);
+    const result = Ogmios.getJSONRPCResult(
+      response.body,
+      data.method,
+      response,
+    );
     return result.transaction.id;
   }
 
@@ -349,19 +499,26 @@ export class Kupmios implements Provider {
     const schema = Ogmios.JSONRPCResponseSchema(S.Array(Ogmios.RedeemerSchema));
 
     // Perform the request and handle the response
-    const response = await pipe(
-      HttpUtils.makePostAsJson(
-        this.ogmiosUrl,
-        data,
-        schema,
-        this.headers?.ogmiosHeader,
+    const response = await runProviderEffect(
+      pipe(
+        HttpUtils.makePostAsJsonResponse(
+          this.ogmiosUrl,
+          data,
+          schema,
+          this.headers?.ogmiosHeader,
+        ),
+        Effect.provide(FetchHttpClient.layer),
+        Effect.timeout(10_000),
+        catchProviderError("ogmios", "evaluateTransaction"),
       ),
-      Effect.provide(FetchHttpClient.layer),
-      Effect.timeout(10_000),
-      Effect.catchAll((cause) => new KupmiosError({ cause })),
-      Effect.runPromise,
+      "ogmios",
+      "evaluateTransaction",
     );
-    const result = Ogmios.getJSONRPCResult(response);
+    const result = Ogmios.getJSONRPCResult(
+      response.body,
+      data.method,
+      response,
+    );
 
     const evalRedeemers: EvalRedeemer[] = result.map((item) => ({
       ex_units: {
@@ -486,19 +643,20 @@ const toProtocolParameters = (
   };
 };
 
-const toDelegation = (result: Ogmios.Delegation): Delegation => {
-  if (!result) {
-    return { poolId: null, rewards: 0n };
-  }
-
-  const delegation = Array.isArray(result)
-    ? result[0]
-    : Object.values(result)[0];
+const toRewardAccountState = (
+  result: Ogmios.Delegation,
+): RewardAccountState => {
+  const delegation = result
+    ? Array.isArray(result)
+      ? result[0]
+      : Object.values(result)[0]
+    : undefined;
   if (!delegation) {
-    return { poolId: null, rewards: 0n };
+    return { registered: false, poolId: null, rewards: 0n };
   }
 
   return {
+    registered: true,
     poolId:
       "stakePool" in delegation
         ? delegation.stakePool?.id || null

--- a/packages/provider/src/maestro.ts
+++ b/packages/provider/src/maestro.ts
@@ -12,7 +12,10 @@ import {
   ProtocolParameters,
   Provider,
   RewardAddress,
+  RewardAccountState,
   Transaction,
+  TransactionStatus,
+  TransactionStatusOptions,
   TxHash,
   Unit,
   UTxO,
@@ -199,20 +202,32 @@ export class Maestro implements Provider {
     return utxos.map(this.maestroUtxoToUtxo);
   }
 
-  async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
-    const timestampedResultResponse = await fetch(
-      `${this.url}/accounts/${rewardAddress}`,
-      { headers: this.commonHeaders() },
-    );
-    if (!timestampedResultResponse.ok) {
-      return { poolId: null, rewards: 0n };
+  async getRewardAccount(
+    rewardAddress: RewardAddress,
+  ): Promise<RewardAccountState> {
+    const response = await fetch(`${this.url}/accounts/${rewardAddress}`, {
+      headers: this.requireAmountsAsStrings(this.commonHeaders()),
+    });
+    if (response.status === 404) {
+      return { registered: false, poolId: null, rewards: 0n };
     }
-    const timestampedResult = await timestampedResultResponse.json();
+    if (!response.ok) {
+      throw new Error(
+        `Could not fetch reward account from Maestro. Received status code: ${response.status}`,
+      );
+    }
+    const timestampedResult = await response.json();
     const result = timestampedResult.data;
     return {
+      registered: result.registered,
       poolId: result.delegated_pool || null,
       rewards: BigInt(result.rewards_available),
     };
+  }
+
+  async getDelegation(rewardAddress: RewardAddress): Promise<Delegation> {
+    const { poolId, rewards } = await this.getRewardAccount(rewardAddress);
+    return { poolId, rewards };
   }
 
   async getDatum(datumHash: DatumHash): Promise<Datum> {
@@ -253,6 +268,47 @@ export class Maestro implements Provider {
         }
       }, checkInterval);
     });
+  }
+
+  async getTransactionStatus(
+    txHash: TxHash,
+    options: TransactionStatusOptions = {},
+  ): Promise<TransactionStatus> {
+    const response = await fetch(`${this.url}/txmanager/${txHash}/state`, {
+      headers: this.commonHeaders(),
+      signal: options.signal,
+    });
+    if (response.status === 404) return { status: "not_found", txHash };
+    if (!response.ok) {
+      throw new Error(
+        `Could not fetch transaction status from Maestro. Received status code: ${response.status}`,
+      );
+    }
+
+    const result = await response.json();
+    switch (result.status) {
+      case "pending":
+        return { status: "pending", txHash };
+      case "confirmed":
+        return {
+          status: "confirmed",
+          txHash,
+          confirmation: {
+            txHash,
+            confirmations: result.confirmations,
+          },
+        };
+      case "failed":
+        return {
+          status: "failed",
+          txHash,
+          reason: result.reason ?? result.error,
+        };
+      default:
+        throw new Error(
+          `Maestro returned an unknown transaction status: ${String(result.status)}`,
+        );
+    }
   }
 
   async submitTx(tx: Transaction): Promise<TxHash> {

--- a/packages/provider/test/blockfrost.test.ts
+++ b/packages/provider/test/blockfrost.test.ts
@@ -1,18 +1,19 @@
 import { assert, describe, expect, test } from "vitest";
 import { ProtocolParameters, UTxO } from "@lucid-evolution/core-types";
-import { Config, Effect } from "effect";
 import { Blockfrost } from "../src/blockfrost.js";
 import * as PreprodConstants from "./preprod-constants.js";
 
-export const blockfrost = await Effect.gen(function* () {
-  const BLOCKFROST_API_URL = yield* Config.string(
-    "VITE_BLOCKFROST_API_URL_PREPROD",
-  );
-  const BLOCKFROST_KEY = yield* Config.string("VITE_BLOCKFROST_KEY_PREPROD");
-  return new Blockfrost(BLOCKFROST_API_URL, BLOCKFROST_KEY);
-}).pipe(Effect.runPromise);
+const BLOCKFROST_API_URL = process.env.VITE_BLOCKFROST_API_URL_PREPROD;
+const BLOCKFROST_KEY = process.env.VITE_BLOCKFROST_KEY_PREPROD;
+const blockfrostDescribe =
+  BLOCKFROST_API_URL && BLOCKFROST_KEY ? describe : describe.skip;
 
-describe("Blockfrost", async () => {
+export const blockfrost = new Blockfrost(
+  BLOCKFROST_API_URL ?? "",
+  BLOCKFROST_KEY ?? "",
+);
+
+blockfrostDescribe("Blockfrost", async () => {
   test("getProtocolParameters", async () => {
     const pp: ProtocolParameters = await blockfrost.getProtocolParameters();
     assert(pp);

--- a/packages/provider/test/emulator.test.ts
+++ b/packages/provider/test/emulator.test.ts
@@ -25,6 +25,28 @@ describe.sequential("Emulator", () => {
     assert.equal(await localEmulator.getTreasury(), treasury);
   });
 
+  test("Get Reward Account distinguishes registration state", async () => {
+    const localEmulator = new Emulator([EMULATOR_ACCOUNT]);
+    const rewardAddress =
+      "stake_test17zt3vxfjx9pjnpnapa65lx375p2utwxmpc8afj053h0l3vgc8a3g3";
+
+    assert.deepEqual(await localEmulator.getRewardAccount(rewardAddress), {
+      registered: false,
+      poolId: null,
+      rewards: 0n,
+    });
+
+    localEmulator.chain[rewardAddress] = {
+      registeredStake: true,
+      delegation: { poolId: null, rewards: 0n },
+    };
+    assert.deepEqual(await localEmulator.getRewardAccount(rewardAddress), {
+      registered: true,
+      poolId: null,
+      rewards: 0n,
+    });
+  });
+
   test("Correct Start Balance", async () => {
     const utxos = await emulator.getUtxos(EMULATOR_ACCOUNT.address);
     const lovelace = utxos.reduce(
@@ -82,6 +104,67 @@ describe.sequential("Emulator", () => {
     assert.equal(
       txHash,
       "edfc1d75074d741f5b7c97e8ddb81de956a43b6fca8664dff5722bb1d136ff3f",
+    );
+
+    const spentEntry = Object.values(emulator.ledger).find(
+      ({ spent }) => spent,
+    );
+    assert.isDefined(spentEntry);
+
+    const spentUnit = `${"f".repeat(56)}01`;
+    spentEntry.utxo.assets[spentUnit] = 1n;
+    const spentOutRef = {
+      txHash: spentEntry.utxo.txHash,
+      outputIndex: spentEntry.utxo.outputIndex,
+    };
+    const includesSpentOutRef = (utxos: (typeof spentEntry.utxo)[]) =>
+      utxos.some(
+        ({ txHash, outputIndex }) =>
+          txHash === spentOutRef.txHash &&
+          outputIndex === spentOutRef.outputIndex,
+      );
+
+    assert.isFalse(
+      includesSpentOutRef(await emulator.getUtxos(spentEntry.utxo.address)),
+    );
+    assert.isFalse(
+      includesSpentOutRef(
+        await emulator.getUtxosWithUnit(spentEntry.utxo.address, spentUnit),
+      ),
+    );
+    assert.isFalse(
+      includesSpentOutRef(await emulator.getUtxosByOutRef([spentOutRef])),
+    );
+    assert.isUndefined(await emulator.getUtxoByUnit(spentUnit));
+
+    assert.deepEqual(await emulator.getTransactionStatus(txHash), {
+      status: "pending",
+      txHash,
+    });
+    emulator.awaitBlock();
+    assert.deepEqual(await emulator.getTransactionStatus(txHash), {
+      status: "confirmed",
+      txHash,
+      confirmation: {
+        txHash,
+        blockHeight: 1,
+        slot: 20,
+        confirmations: 1,
+      },
+    });
+    const confirmedOutput = Object.entries(emulator.ledger).find(
+      ([, { utxo }]) => utxo.txHash === txHash,
+    );
+    assert.isDefined(confirmedOutput);
+    confirmedOutput[1].spent = true;
+    emulator.awaitBlock(2);
+    assert.notProperty(emulator.ledger, confirmedOutput[0]);
+    assert.equal(
+      (await emulator.getTransactionStatus(txHash)).status === "confirmed"
+        ? (await emulator.getTransactionStatus(txHash)).confirmation
+            .confirmations
+        : undefined,
+      3,
     );
   });
 });

--- a/packages/provider/test/kupmios-errors.test.ts
+++ b/packages/provider/test/kupmios-errors.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Kupmios, KupmiosError, OgmiosJsonRpcError } from "../src/index.js";
+
+const txHash = "0".repeat(64);
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("Kupmios structured errors", () => {
+  test("preserves Ogmios JSON-RPC error code, data, method, and operation", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "evaluateTransaction",
+          id: null,
+          error: {
+            code: 3010,
+            message: "Some inputs are already spent",
+            data: { badInputs: ["abcd#0"] },
+          },
+        }),
+        {
+          status: 400,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const error = await provider.evaluateTx("00").catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(KupmiosError);
+    expect(error).toBeInstanceOf(OgmiosJsonRpcError);
+    expect(error).toMatchObject({
+      name: "OgmiosJsonRpcError",
+      provider: "Kupmios",
+      protocol: "ogmios",
+      operation: "evaluateTransaction",
+      kind: "json_rpc",
+      retryable: false,
+      status: 400,
+      code: 3010,
+      data: { badInputs: ["abcd#0"] },
+      method: "evaluateTransaction",
+      id: null,
+    });
+  });
+
+  test("combines JSON-RPC and HTTP retry metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: null,
+          error: { code: -32000, message: "temporarily unavailable" },
+        }),
+        {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": "2",
+          },
+        },
+      ),
+    );
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const error = await provider.getTreasury().catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(OgmiosJsonRpcError);
+    expect(error).toMatchObject({
+      code: -32000,
+      status: 429,
+      retryable: true,
+      retryAfterMs: 2_000,
+    });
+  });
+
+  test("preserves HTTP status and Retry-After metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("rate limited", {
+        status: 429,
+        headers: { "retry-after": "2" },
+      }),
+    );
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const error = await provider
+      .getTransactionStatus(txHash)
+      .catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(KupmiosError);
+    expect(error).toMatchObject({
+      provider: "Kupmios",
+      protocol: "kupo",
+      operation: "getTransactionStatus",
+      kind: "http",
+      status: 429,
+      retryable: true,
+      retryAfterMs: 2_000,
+    });
+    expect(error.cause).toBeDefined();
+  });
+
+  test("does not mark ordinary client errors retryable", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("bad request", { status: 400 }),
+    );
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const error = await provider
+      .getTransactionStatus(txHash)
+      .catch((cause) => cause);
+
+    expect(error).toMatchObject({
+      kind: "http",
+      status: 400,
+      retryable: false,
+    });
+  });
+
+  test("classifies invalid provider payloads as decode failures", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ invalid: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const error = await provider
+      .getTransactionStatus(txHash)
+      .catch((cause) => cause);
+
+    expect(error).toBeInstanceOf(KupmiosError);
+    expect(error).toMatchObject({
+      protocol: "kupo",
+      operation: "getTransactionStatus",
+      kind: "decode",
+      retryable: false,
+    });
+  });
+
+  test("classifies provider operation deadlines as retryable timeouts", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => await new Promise<Response>(() => undefined),
+    );
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const result = provider
+      .getTransactionStatus(txHash)
+      .catch((cause) => cause);
+    await vi.advanceTimersByTimeAsync(10_000);
+    const error = await result;
+
+    expect(error).toBeInstanceOf(KupmiosError);
+    expect(error).toMatchObject({
+      protocol: "kupo",
+      operation: "getTransactionStatus",
+      kind: "timeout",
+      retryable: true,
+    });
+    expect(error.cause).toBeDefined();
+  });
+
+  test("turns AbortSignal cancellation into a normal typed Error", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("caller cancelled"));
+    const fetch = vi.spyOn(globalThis, "fetch");
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const error = await provider
+      .getTransactionStatus(txHash, { signal: controller.signal })
+      .catch((cause) => cause);
+
+    expect(fetch).not.toHaveBeenCalled();
+    expect(error).toBeInstanceOf(Error);
+    expect(error).toBeInstanceOf(KupmiosError);
+    expect(error).toMatchObject({
+      protocol: "kupo",
+      operation: "getTransactionStatus",
+      kind: "aborted",
+      retryable: false,
+    });
+    expect(error.cause).toBe(controller.signal.reason);
+  });
+
+  test("interrupts an in-flight Kupo request when the caller aborts", async () => {
+    let requestSignal: AbortSignal | undefined;
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        requestSignal = new Request(input, init).signal;
+        return await new Promise<Response>((_resolve, reject) => {
+          requestSignal!.addEventListener(
+            "abort",
+            () => reject(requestSignal!.reason),
+            { once: true },
+          );
+        });
+      });
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+    const controller = new AbortController();
+    const reason = new Error("caller cancelled in flight");
+
+    const result = provider
+      .getTransactionStatus(txHash, { signal: controller.signal })
+      .catch((cause) => cause);
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledOnce());
+    controller.abort(reason);
+    const error = await result;
+
+    expect(requestSignal?.aborted).toBe(true);
+    expect(error).toBeInstanceOf(KupmiosError);
+    expect(error).toMatchObject({
+      operation: "getTransactionStatus",
+      kind: "aborted",
+      retryable: false,
+      cause: reason,
+    });
+  });
+});

--- a/packages/provider/test/kupmios-ogmios.test.ts
+++ b/packages/provider/test/kupmios-ogmios.test.ts
@@ -187,6 +187,55 @@ describe("Kupmios Ogmios JSON-RPC handling", () => {
   });
 
   test("getDelegation accepts Ogmios reward account summaries", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            method: "queryLedgerState/rewardAccountSummaries",
+            result: [
+              {
+                from: "script",
+                credential:
+                  "97161932314329867d0f754f9a3ea055c5b8db0e0fd4c9f48ddff8b1",
+                stakePool: {
+                  id: "pool1e0arfuamnymdkmjztvkryasxv9d8u8key27ajgc4mquz2nr8mk9",
+                },
+                rewards: { ada: { lovelace: 1505083629601 } },
+                deposit: { ada: { lovelace: 2000000 } },
+              },
+            ],
+            id: null,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+    const kupmios = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    await expect(
+      kupmios.getRewardAccount(
+        "stake_test17zt3vxfjx9pjnpnapa65lx375p2utwxmpc8afj053h0l3vgc8a3g3",
+      ),
+    ).resolves.toStrictEqual({
+      registered: true,
+      poolId: "pool1e0arfuamnymdkmjztvkryasxv9d8u8key27ajgc4mquz2nr8mk9",
+      rewards: 1505083629601n,
+    });
+
+    await expect(
+      kupmios.getDelegation(
+        "stake_test17zt3vxfjx9pjnpnapa65lx375p2utwxmpc8afj053h0l3vgc8a3g3",
+      ),
+    ).resolves.toStrictEqual({
+      poolId: "pool1e0arfuamnymdkmjztvkryasxv9d8u8key27ajgc4mquz2nr8mk9",
+      rewards: 1505083629601n,
+    });
+  });
+
+  test("getRewardAccount accepts current verification-key summaries without delegation", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(
         JSON.stringify({
@@ -194,14 +243,11 @@ describe("Kupmios Ogmios JSON-RPC handling", () => {
           method: "queryLedgerState/rewardAccountSummaries",
           result: [
             {
-              from: "script",
+              from: "verificationKey",
               credential:
-                "97161932314329867d0f754f9a3ea055c5b8db0e0fd4c9f48ddff8b1",
-              stakePool: {
-                id: "pool1e0arfuamnymdkmjztvkryasxv9d8u8key27ajgc4mquz2nr8mk9",
-              },
-              rewards: { ada: { lovelace: 1505083629601 } },
-              deposit: { ada: { lovelace: 2000000 } },
+                "e05ebf0d29c5e5267758d35c7554541ce5e2b278eaf542e367057c8a",
+              rewards: { ada: { lovelace: 0 } },
+              deposit: { ada: { lovelace: 2_000_000 } },
             },
           ],
           id: null,
@@ -215,31 +261,43 @@ describe("Kupmios Ogmios JSON-RPC handling", () => {
     const kupmios = new Kupmios("http://kupo.test", "http://ogmios.test");
 
     await expect(
-      kupmios.getDelegation(
+      kupmios.getRewardAccount(
         "stake_test17zt3vxfjx9pjnpnapa65lx375p2utwxmpc8afj053h0l3vgc8a3g3",
       ),
     ).resolves.toStrictEqual({
-      poolId: "pool1e0arfuamnymdkmjztvkryasxv9d8u8key27ajgc4mquz2nr8mk9",
-      rewards: 1505083629601n,
+      registered: true,
+      poolId: null,
+      rewards: 0n,
     });
   });
 
   test("getDelegation returns empty delegation for empty Ogmios summaries", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(
-        JSON.stringify({
-          jsonrpc: "2.0",
-          method: "queryLedgerState/rewardAccountSummaries",
-          result: [],
-          id: null,
-        }),
-        {
-          status: 200,
-          headers: { "content-type": "application/json" },
-        },
-      ),
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            method: "queryLedgerState/rewardAccountSummaries",
+            result: [],
+            id: null,
+          }),
+          {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          },
+        ),
     );
     const kupmios = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    await expect(
+      kupmios.getRewardAccount(
+        "stake_test17zt3vxfjx9pjnpnapa65lx375p2utwxmpc8afj053h0l3vgc8a3g3",
+      ),
+    ).resolves.toStrictEqual({
+      registered: false,
+      poolId: null,
+      rewards: 0n,
+    });
 
     await expect(
       kupmios.getDelegation(
@@ -248,6 +306,54 @@ describe("Kupmios Ogmios JSON-RPC handling", () => {
     ).resolves.toStrictEqual({
       poolId: null,
       rewards: 0n,
+    });
+  });
+
+  test("evaluateTx sends supplemental UTxOs to Ogmios", async () => {
+    let requestBody: unknown;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const body = await new Request(input, init).text();
+      requestBody = JSON.parse(body);
+
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          method: "evaluateTransaction",
+          result: [],
+          id: null,
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    });
+    const kupmios = new Kupmios("http://kupo.test", "http://ogmios.test");
+    const supplementalUtxo = {
+      txHash:
+        "0000000000000000000000000000000000000000000000000000000000000000",
+      outputIndex: 1,
+      address:
+        "addr_test1qrngfyc452vy4twdrepdjc50d4kvqutgt0hs9w6j2qhcdjfx0gpv7rsrjtxv97rplyz3ymyaqdwqa635zrcdena94ljs0xy950",
+      assets: { lovelace: 1_234_567n },
+    };
+
+    await expect(
+      kupmios.evaluateTx("80", [supplementalUtxo]),
+    ).resolves.toStrictEqual([]);
+    expect(requestBody).toMatchObject({
+      method: "evaluateTransaction",
+      params: {
+        transaction: { cbor: "80" },
+        additionalUtxo: [
+          {
+            transaction: { id: supplementalUtxo.txHash },
+            index: supplementalUtxo.outputIndex,
+            address: supplementalUtxo.address,
+            value: { ada: { lovelace: 1_234_567 } },
+          },
+        ],
+      },
     });
   });
 

--- a/packages/provider/test/provider-capabilities.test.ts
+++ b/packages/provider/test/provider-capabilities.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { Blockfrost, Koios, Kupmios, Maestro } from "../src/index.js";
+
+const rewardAddress =
+  "stake_test17zt3vxfjx9pjnpnapa65lx375p2utwxmpc8afj053h0l3vgc8a3g3";
+const txHash = "a".repeat(64);
+
+const jsonResponse = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("built-in provider reward-account capabilities", () => {
+  test("Maestro preserves registered but undelegated state", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      jsonResponse({
+        data: {
+          registered: true,
+          delegated_pool: null,
+          rewards_available: "0",
+        },
+      }),
+    );
+    const provider = new Maestro({ network: "Preprod", apiKey: "test" });
+
+    await expect(provider.getRewardAccount(rewardAddress)).resolves.toEqual({
+      registered: true,
+      poolId: null,
+      rewards: 0n,
+    });
+    await expect(provider.getDelegation(rewardAddress)).resolves.toEqual({
+      poolId: null,
+      rewards: 0n,
+    });
+  });
+
+  test("Maestro maps a missing account to unregistered", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({ message: "not found" }, 404),
+    );
+    const provider = new Maestro({ network: "Preprod", apiKey: "test" });
+
+    await expect(provider.getRewardAccount(rewardAddress)).resolves.toEqual({
+      registered: false,
+      poolId: null,
+      rewards: 0n,
+    });
+  });
+
+  test("Blockfrost exposes account registration", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        active: true,
+        pool_id: null,
+        withdrawable_amount: "42",
+      }),
+    );
+    const provider = new Blockfrost("http://blockfrost.test", "test");
+
+    await expect(provider.getRewardAccount(rewardAddress)).resolves.toEqual({
+      registered: true,
+      poolId: null,
+      rewards: 42n,
+    });
+  });
+
+  test("Koios uses its explicit account status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse([
+        {
+          status: "not registered",
+          delegated_pool: null,
+          rewards_available: "0",
+        },
+      ]),
+    );
+    const provider = new Koios("http://koios.test");
+
+    await expect(provider.getRewardAccount(rewardAddress)).resolves.toEqual({
+      registered: false,
+      poolId: null,
+      rewards: 0n,
+    });
+  });
+});
+
+describe("built-in provider transaction-status capabilities", () => {
+  test("Kupmios recognizes confirmed transactions after their outputs are spent", async () => {
+    const match = {
+      transaction_index: 0,
+      transaction_id: txHash,
+      output_index: 0,
+      address: "addr_test1confirmed",
+      value: { coins: "2000000", assets: {} },
+      datum_hash: null,
+      script_hash: null,
+      created_at: { slot_no: 123, header_hash: "b".repeat(64) },
+      spent_at: { slot_no: 124, header_hash: "c".repeat(64) },
+    };
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () => jsonResponse([match]));
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    await expect(provider.getTransactionStatus(txHash)).resolves.toEqual({
+      status: "confirmed",
+      txHash,
+      confirmation: {
+        txHash,
+        blockHash: "b".repeat(64),
+        slot: 123,
+      },
+    });
+    expect(String(fetch.mock.calls[0]?.[0])).toBe(
+      `http://kupo.test/matches/*@${txHash}`,
+    );
+
+    fetch.mockClear();
+    await expect(provider.awaitTx(txHash, 1)).resolves.toBe(true);
+    expect(String(fetch.mock.calls[0]?.[0])).toBe(
+      `http://kupo.test/matches/*@${txHash}`,
+    );
+  });
+
+  test("Maestro exposes pending, confirmed, and failed states", async () => {
+    vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        jsonResponse({ tx_hash: txHash, status: "pending", confirmations: 0 }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          tx_hash: txHash,
+          status: "confirmed",
+          confirmations: 7,
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          tx_hash: txHash,
+          status: "failed",
+          reason: "rejected",
+          confirmations: 0,
+        }),
+      );
+    const provider = new Maestro({ network: "Preprod", apiKey: "test" });
+
+    await expect(provider.getTransactionStatus(txHash)).resolves.toEqual({
+      status: "pending",
+      txHash,
+    });
+    await expect(provider.getTransactionStatus(txHash)).resolves.toEqual({
+      status: "confirmed",
+      txHash,
+      confirmation: { txHash, confirmations: 7 },
+    });
+    await expect(provider.getTransactionStatus(txHash)).resolves.toEqual({
+      status: "failed",
+      txHash,
+      reason: "rejected",
+    });
+  });
+
+  test("Blockfrost exposes confirmed inclusion metadata", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse({
+        hash: txHash,
+        block: "b".repeat(64),
+        block_height: 123,
+        slot: 456,
+      }),
+    );
+    const provider = new Blockfrost("http://blockfrost.test", "test");
+
+    await expect(provider.getTransactionStatus(txHash)).resolves.toEqual({
+      status: "confirmed",
+      txHash,
+      confirmation: {
+        txHash,
+        blockHash: "b".repeat(64),
+        blockHeight: 123,
+        slot: 456,
+      },
+    });
+  });
+
+  test("Koios exposes actual block confirmation counts", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse([{ tx_hash: txHash, num_confirmations: 12 }]),
+    );
+    const provider = new Koios("http://koios.test");
+
+    await expect(provider.getTransactionStatus(txHash)).resolves.toEqual({
+      status: "confirmed",
+      txHash,
+      confirmation: { txHash, confirmations: 12 },
+    });
+  });
+
+  test("all index-only providers return not_found without inventing pending", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch");
+    const blockfrost = new Blockfrost("http://blockfrost.test", "test");
+    const koios = new Koios("http://koios.test");
+
+    fetch.mockResolvedValueOnce(jsonResponse({ message: "not found" }, 404));
+    await expect(blockfrost.getTransactionStatus(txHash)).resolves.toEqual({
+      status: "not_found",
+      txHash,
+    });
+
+    fetch.mockResolvedValueOnce(
+      jsonResponse([{ tx_hash: txHash, num_confirmations: null }]),
+    );
+    await expect(koios.getTransactionStatus(txHash)).resolves.toEqual({
+      status: "not_found",
+      txHash,
+    });
+  });
+});
+
+describe("Kupmios policy fast path", () => {
+  test("keeps empty-name unit queries exact instead of treating them as policy queries", async () => {
+    const policyId = "a".repeat(56);
+    const emptyNameMatch = {
+      transaction_index: 0,
+      transaction_id: "1".repeat(64),
+      output_index: 0,
+      address: "addr_test1query",
+      value: { coins: "2000000", assets: { [`${policyId}.`]: "1" } },
+      datum_hash: null,
+      script_hash: null,
+      created_at: { slot_no: 123, header_hash: "b".repeat(64) },
+      spent_at: null,
+    };
+    const otherAssetMatch = {
+      ...emptyNameMatch,
+      transaction_id: "2".repeat(64),
+      output_index: 1,
+      value: { coins: "2000000", assets: { [`${policyId}.01`]: "1" } },
+    };
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async () =>
+        jsonResponse([emptyNameMatch, otherAssetMatch]),
+      );
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    await expect(
+      provider.getUtxosWithUnit("addr_test1query", policyId),
+    ).resolves.toMatchObject([
+      { txHash: emptyNameMatch.transaction_id, outputIndex: 0 },
+    ]);
+    expect(String(fetch.mock.calls[0]?.[0])).toBe(
+      `http://kupo.test/matches/addr_test1query?unspent&policy_id=${policyId}`,
+    );
+
+    fetch.mockClear();
+    fetch.mockImplementation(async () => jsonResponse([emptyNameMatch]));
+    await expect(provider.getUtxoByUnit(policyId)).resolves.toMatchObject({
+      txHash: emptyNameMatch.transaction_id,
+      outputIndex: 0,
+    });
+    expect(String(fetch.mock.calls[0]?.[0])).toBe(
+      `http://kupo.test/matches/${policyId}.?unspent`,
+    );
+  });
+
+  test("uses Kupo's policy_id filter without adding exact-unit semantics", async () => {
+    const fetch = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(jsonResponse([]));
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+    const policyId = "A".repeat(56);
+
+    await expect(
+      provider.getUtxosWithPolicy("addr_test1query", policyId),
+    ).resolves.toEqual([]);
+    expect(String(fetch.mock.calls[0]?.[0])).toBe(
+      `http://kupo.test/matches/addr_test1query?unspent&policy_id=${policyId.toLowerCase()}`,
+    );
+  });
+
+  test("rejects malformed policy identifiers before querying Kupo", async () => {
+    const fetch = vi.spyOn(globalThis, "fetch");
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    await expect(
+      provider.getUtxosWithPolicy("addr_test1query", "abcd"),
+    ).rejects.toThrow("56-character hexadecimal");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/provider/test/provider-compatibility.test.ts
+++ b/packages/provider/test/provider-compatibility.test.ts
@@ -1,0 +1,37 @@
+import type { Provider } from "@lucid-evolution/core-types";
+import { KupmiosError } from "../src/index.js";
+import { expect, test } from "vitest";
+
+const notImplemented = async (): Promise<never> => {
+  throw new Error("not implemented");
+};
+
+/**
+ * Compile-time fixture for third-party providers that implement the interface
+ * that predates optional provider capabilities.
+ */
+const legacyProvider: Provider = {
+  getProtocolParameters: notImplemented,
+  getUtxos: async () => [],
+  getUtxosWithUnit: async () => [],
+  getUtxoByUnit: notImplemented,
+  getUtxosByOutRef: async () => [],
+  getDelegation: async () => ({ poolId: null, rewards: 0n }),
+  getDatum: notImplemented,
+  awaitTx: async () => true,
+  submitTx: async () => "0".repeat(64),
+  evaluateTx: async () => [],
+};
+
+test("legacy providers remain structurally compatible", () => {
+  expect(legacyProvider.awaitTx).toBeTypeOf("function");
+});
+
+test("the legacy KupmiosError constructor remains source-compatible", () => {
+  const cause = new Error("legacy failure");
+  const error = new KupmiosError({ cause });
+
+  expect(error).toBeInstanceOf(Error);
+  expect(error.cause).toBe(cause);
+  expect(error._tag).toBe("KupmiosError");
+});

--- a/packages/wallet/src/wallet_selection.ts
+++ b/packages/wallet/src/wallet_selection.ts
@@ -27,7 +27,7 @@ import { signData } from "@lucid-evolution/sign_data";
 import { discoverOwnUsedTxKeyHashes, walletFromSeed } from "./wallet.js";
 
 type Config = {
-  overriddenUTxOs: UTxO[];
+  overriddenUTxOs: UTxO[] | undefined;
 };
 
 const signTxsSequentially = async (
@@ -96,7 +96,7 @@ export const makeWalletFromSeed = (
   },
 ): Wallet => {
   const config: Config = {
-    overriddenUTxOs: [],
+    overriddenUTxOs: undefined,
   };
 
   const { address, rewardAddress, paymentKey, stakeKey } = walletFromSeed(
@@ -124,7 +124,7 @@ export const makeWalletFromSeed = (
     tx: CML.Transaction,
   ): Promise<CML.TransactionWitnessSet> => {
     const utxos =
-      config.overriddenUTxOs.length > 0
+      config.overriddenUTxOs !== undefined
         ? config.overriddenUTxOs
         : await provider.getUtxos(address);
 
@@ -146,16 +146,17 @@ export const makeWalletFromSeed = (
   };
   return {
     overrideUTxOs: (utxos: UTxO[]) => (config.overriddenUTxOs = utxos),
+    clearUTxOOverride: () => (config.overriddenUTxOs = undefined),
     address: async (): Promise<Address> => address,
     rewardAddress: async (): Promise<RewardAddress | null> =>
       rewardAddress || null,
     getUtxos: async (): Promise<UTxO[]> =>
-      config.overriddenUTxOs.length > 0
+      config.overriddenUTxOs !== undefined
         ? config.overriddenUTxOs
         : provider.getUtxos(address),
     getUtxosCore: async (): Promise<CML.TransactionUnspentOutput[]> => {
       const utxos =
-        config.overriddenUTxOs.length > 0
+        config.overriddenUTxOs !== undefined
           ? config.overriddenUTxOs
           : await provider.getUtxos(address);
       const coreUtxos: CML.TransactionUnspentOutput[] = [];
@@ -217,7 +218,7 @@ export const makeWalletFromPrivateKey = (
     .to_address()
     .to_bech32(undefined);
   const config: Config = {
-    overriddenUTxOs: [],
+    overriddenUTxOs: undefined,
   };
   const signTx = async (
     tx: CML.Transaction,
@@ -233,15 +234,16 @@ export const makeWalletFromPrivateKey = (
 
   return {
     overrideUTxOs: (utxos: UTxO[]) => (config.overriddenUTxOs = utxos),
+    clearUTxOOverride: () => (config.overriddenUTxOs = undefined),
     address: async (): Promise<Address> => address,
     rewardAddress: async (): Promise<RewardAddress | null> => null,
     getUtxos: async (): Promise<UTxO[]> =>
-      config.overriddenUTxOs.length > 0
+      config.overriddenUTxOs !== undefined
         ? config.overriddenUTxOs
         : provider.getUtxos(address),
     getUtxosCore: async (): Promise<CML.TransactionUnspentOutput[]> => {
       const utxos =
-        config.overriddenUTxOs.length > 0
+        config.overriddenUTxOs !== undefined
           ? config.overriddenUTxOs
           : await provider.getUtxos(address);
       const coreUtxos: CML.TransactionUnspentOutput[] = [];
@@ -288,7 +290,7 @@ export const makeWalletFromAPI = (
   api: WalletApi,
 ): Wallet => {
   const config: Config = {
-    overriddenUTxOs: [],
+    overriddenUTxOs: undefined,
   };
   const getAddressHex = async () => {
     const [addressHex] = await api.getUsedAddresses();
@@ -310,13 +312,14 @@ export const makeWalletFromAPI = (
 
   return {
     overrideUTxOs: (utxos: UTxO[]) => (config.overriddenUTxOs = utxos),
+    clearUTxOOverride: () => (config.overriddenUTxOs = undefined),
     address: async (): Promise<Address> =>
       CML.Address.from_hex(await getAddressHex()).to_bech32(undefined),
     rewardAddress: async (): Promise<RewardAddress | null> =>
       getRewardAddress(),
     getUtxos: async (): Promise<UTxO[]> => {
       const utxos =
-        config.overriddenUTxOs.length > 0
+        config.overriddenUTxOs !== undefined
           ? config.overriddenUTxOs
           : ((await api.getUtxos()) || []).map((utxo) =>
               coreToUtxo(
@@ -327,7 +330,7 @@ export const makeWalletFromAPI = (
     },
     getUtxosCore: async (): Promise<CML.TransactionUnspentOutput[]> => {
       const utxos =
-        config.overriddenUTxOs.length > 0
+        config.overriddenUTxOs !== undefined
           ? config.overriddenUTxOs.map(utxoToCore)
           : ((await api.getUtxos()) || []).map((utxo: string) =>
               CML.TransactionUnspentOutput.from_cbor_hex(utxo),
@@ -397,15 +400,16 @@ export const makeWalletFromAddress = (
   };
   return {
     overrideUTxOs: (utxos: UTxO[]) => (config.overriddenUTxOs = utxos),
+    clearUTxOOverride: () => (config.overriddenUTxOs = undefined),
     address: async (): Promise<Address> => address,
     rewardAddress: async (): Promise<RewardAddress | null> => rewardAddress,
     getUtxos: async (): Promise<UTxO[]> =>
-      config.overriddenUTxOs.length > 0
+      config.overriddenUTxOs !== undefined
         ? config.overriddenUTxOs
         : provider.getUtxos(address),
     getUtxosCore: async (): Promise<CML.TransactionUnspentOutput[]> => {
       const utxos =
-        config.overriddenUTxOs.length > 0
+        config.overriddenUTxOs !== undefined
           ? config.overriddenUTxOs
           : await provider.getUtxos(address);
       const coreUtxos: CML.TransactionUnspentOutput[] = [];

--- a/packages/wallet/test/utxo_override.test.ts
+++ b/packages/wallet/test/utxo_override.test.ts
@@ -1,0 +1,101 @@
+import type {
+  Provider,
+  UTxO,
+  Wallet,
+  WalletApi,
+} from "@lucid-evolution/core-types";
+import { generatePrivateKey, generateSeedPhrase } from "@lucid-evolution/utils";
+import { describe, expect, test, vi } from "vitest";
+import {
+  makeWalletFromAddress,
+  makeWalletFromAPI,
+  makeWalletFromPrivateKey,
+  makeWalletFromSeed,
+} from "../src/wallet_selection.js";
+
+const providerUtxo: UTxO = {
+  txHash: "0".repeat(64),
+  outputIndex: 0,
+  address: "provider-result",
+  assets: { lovelace: 1n },
+};
+
+const makeProvider = () => {
+  const getUtxos = vi.fn(async () => [providerUtxo]);
+  return {
+    getUtxos,
+    provider: { getUtxos } as unknown as Provider,
+  };
+};
+
+const expectAuthoritativeEmptyOverride = async (
+  wallet: Wallet,
+  source: ReturnType<typeof vi.fn>,
+) => {
+  expect(wallet.clearUTxOOverride).toBeTypeOf("function");
+
+  wallet.overrideUTxOs([]);
+  expect(await wallet.getUtxos()).toEqual([]);
+  expect(await wallet.getUtxosCore()).toEqual([]);
+  expect(source).not.toHaveBeenCalled();
+
+  wallet.clearUTxOOverride!();
+  expect(await wallet.getUtxos()).toEqual([providerUtxo]);
+  expect(source).toHaveBeenCalledOnce();
+};
+
+describe("authoritative wallet UTxO overrides", () => {
+  test("seed wallet treats [] as authoritative until cleared", async () => {
+    const { provider, getUtxos } = makeProvider();
+    const wallet = makeWalletFromSeed(
+      provider,
+      "Preprod",
+      generateSeedPhrase(),
+    );
+
+    await expectAuthoritativeEmptyOverride(wallet, getUtxos);
+  });
+
+  test("private-key wallet treats [] as authoritative until cleared", async () => {
+    const { provider, getUtxos } = makeProvider();
+    const wallet = makeWalletFromPrivateKey(
+      provider,
+      "Preprod",
+      generatePrivateKey(),
+    );
+
+    await expectAuthoritativeEmptyOverride(wallet, getUtxos);
+  });
+
+  test("address wallet treats its initial [] as authoritative until cleared", async () => {
+    const privateKey = generatePrivateKey();
+    const addressProvider = makeProvider().provider;
+    const address = await makeWalletFromPrivateKey(
+      addressProvider,
+      "Preprod",
+      privateKey,
+    ).address();
+    const { provider, getUtxos } = makeProvider();
+    const wallet = makeWalletFromAddress(provider, "Preprod", address, []);
+
+    expect(await wallet.getUtxos()).toEqual([]);
+    expect(getUtxos).not.toHaveBeenCalled();
+    await expectAuthoritativeEmptyOverride(wallet, getUtxos);
+  });
+
+  test("CIP-30 wallet treats [] as authoritative until cleared", async () => {
+    const getUtxos = vi.fn(async () => []);
+    const api = { getUtxos } as unknown as WalletApi;
+    const wallet = makeWalletFromAPI({} as Provider, api);
+
+    expect(wallet.clearUTxOOverride).toBeTypeOf("function");
+    wallet.overrideUTxOs([]);
+    expect(await wallet.getUtxos()).toEqual([]);
+    expect(await wallet.getUtxosCore()).toEqual([]);
+    expect(getUtxos).not.toHaveBeenCalled();
+
+    wallet.clearUTxOOverride!();
+    expect(await wallet.getUtxos()).toEqual([]);
+    expect(getUtxos).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- filter spent entries from every public Emulator UTxO query and retain truthful transaction history after outputs are consumed
- make empty wallet UTxO overrides authoritative, add `clearUTxOOverride()`, and preserve `undefined` as provider refresh
- add structured Kupmios and Ogmios errors with JSON-RPC, HTTP, retry, timeout, abort, operation, and cause metadata
- add provider-neutral transaction status and cancellable confirmation APIs while retaining the existing boolean `awaitTx`
- remove the Kupmios `?unspent` confirmation false-negative and expose supported status metadata across built-in providers
- replace runtime-global custom-network timing with validated per-Lucid-instance slot configuration
- expose provider-neutral reward-account registration state while retaining `getDelegation`
- add an optional policy-ID query capability with a correct portable fallback and native Kupmios fast path

## Compatibility

The new provider capabilities are optional, existing `getDelegation` and `awaitTx` contracts remain available, legacy Kupmios error construction remains source-compatible, and third-party wallet/provider implementations continue to type-check. Providers only report confirmation depth or failure metadata when their upstream API supplies it.

## Notable correctness details

- Kupmios transaction lookup searches historical matches rather than only currently unspent outputs.
- Minimum confirmation counts greater than one require a provider that reports actual depth.
- Exact empty asset-name unit queries do not broaden into policy-wide matches.
- Ogmios transaction evaluation continues to include supplemental UTxOs required for locally constructed inputs.
- Custom slot configuration is copied, frozen, validated, and propagated through building, signing, evaluation, and script-context reconstruction.

## Verification

- provider tests: 66 passed, 43 skipped
- wallet tests: 15 passed
- Lucid non-live tests: 145 passed, 59 skipped
- `pnpm build`: 14/14 packages
- `pnpm lint`: 22/22 packages
- scoped formatting and `git diff --check`: clean
- Changesets validation: clean
- read-only local Kupo/Ogmios smoke checks for transaction status, reward accounts, policy queries, protocol parameters, and empty asset-name patterns

A Changeset and documentation updates are included.
