### PR TITLE
fix: accumulate repeated governance actions per voter

### DIFF
--- a/.changeset/tidy-dreps-vote.md
+++ b/.changeset/tidy-dreps-vote.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/lucid": patch
+---
+
+Accumulate governance actions when `TxBuilder.vote()` is called repeatedly for the same voter instead of retaining only the final action.

--- a/packages/lucid/src/tx-builder/TxBuilder.ts
+++ b/packages/lucid/src/tx-builder/TxBuilder.ts
@@ -100,6 +100,8 @@ export type TxBuilderConfig = {
   nextActionId: number;
   pendingRedeemers: PendingRedeemer[];
   witnessRegistry: Set<string>;
+  /** Accumulates one result because CML replaces voter maps across results. */
+  governanceVoteBuilder?: CML.VoteBuilder;
   governanceVoteWitnessKeys: string[];
   governanceProposalWitnessIndices: bigint[];
   governanceProposalCount: bigint;
@@ -154,6 +156,7 @@ export const replayTxActions = (
     for (const action of actions) {
       yield* replayAction(action, currentRedeemers);
     }
+    yield* GovernanceAction.finalizeVotes();
   });
 
 export const hasDelayedActions = (config: TxBuilderConfig): boolean =>
@@ -186,6 +189,7 @@ export const makeTxBuilderConfig = (
   nextActionId: source?.nextActionId ?? 0,
   pendingRedeemers: [],
   witnessRegistry: new Set(),
+  governanceVoteBuilder: undefined,
   governanceVoteWitnessKeys: [],
   governanceProposalWitnessIndices: [],
   governanceProposalCount: 0n,

--- a/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
+++ b/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
@@ -47,6 +47,7 @@ import {
 } from "@lucid-evolution/utils";
 import { collectFromUTxO } from "./Collect.js";
 import { TxConfig } from "./Service.js";
+import * as GovernanceAction from "./GovernanceAction.js";
 import { isError } from "effect/Predicate";
 import {
   hasDelayedActions,
@@ -216,6 +217,7 @@ const completeCurrentConfig = (
 
     // Execute programs sequentially
     yield* Effect.all(config.programs);
+    yield* GovernanceAction.finalizeVotes();
     yield* applyTreasuryDonationToBuilder(config);
     const hasPlutusScriptExecutions: boolean = Array.from(
       config.scripts.values(),

--- a/packages/lucid/src/tx-builder/internal/GovernanceAction.ts
+++ b/packages/lucid/src/tx-builder/internal/GovernanceAction.ts
@@ -359,11 +359,14 @@ export const vote = (
       toCMLVote(voteChoice),
       anchor ? toCMLAnchor(anchor) : undefined,
     );
-    let builder = CML.VoteBuilder.new();
+    let builder = config.governanceVoteBuilder ?? CML.VoteBuilder.new();
     const credential = voterCredential(voter);
 
     if (!credential || credential.type === "Key") {
-      builder = builder.with_vote(cmlVoter, cmlActionId, procedure);
+      builder = yield* Effect.try({
+        try: () => builder.with_vote(cmlVoter, cmlActionId, procedure),
+        catch: governanceActionError,
+      });
     } else {
       const script = yield* pipe(
         Effect.fromNullable(config.scripts.get(credential.hash)),
@@ -373,13 +376,17 @@ export const vote = (
       );
 
       if (script.type === "Native") {
-        builder = builder.with_native_script_vote(
-          cmlVoter,
-          cmlActionId,
-          procedure,
-          CML.NativeScript.from_cbor_hex(script.script),
-          CML.NativeScriptWitnessInfo.assume_signature_count(),
-        );
+        builder = yield* Effect.try({
+          try: () =>
+            builder.with_native_script_vote(
+              cmlVoter,
+              cmlActionId,
+              procedure,
+              CML.NativeScript.from_cbor_hex(script.script),
+              CML.NativeScriptWitnessInfo.assume_signature_count(),
+            ),
+          catch: governanceActionError,
+        });
       } else {
         if (script.type !== "PlutusV3") {
           yield* governanceActionError(
@@ -399,24 +406,42 @@ export const vote = (
           ),
         );
         const partial = toPartial(toV3(script.script), red);
-        builder = builder.with_plutus_vote(
-          cmlVoter,
-          cmlActionId,
-          procedure,
-          partial,
-          CML.Ed25519KeyHashList.new(),
-          CML.PlutusData.from_cbor_hex(red),
-        );
+        builder = yield* Effect.try({
+          try: () =>
+            builder.with_plutus_vote(
+              cmlVoter,
+              cmlActionId,
+              procedure,
+              partial,
+              CML.Ed25519KeyHashList.new(),
+              CML.PlutusData.from_cbor_hex(red),
+            ),
+          catch: governanceActionError,
+        });
       }
     }
+
+    config.governanceVoteBuilder = builder;
+    if (credential?.type === "Script") {
+      config.governanceVoteWitnessKeys.push(cmlVoter.to_canonical_cbor_hex());
+    }
+  });
+
+export const finalizeVotes = (): Effect.Effect<
+  void,
+  TransactionError,
+  TxConfig
+> =>
+  Effect.gen(function* () {
+    const { config } = yield* TxConfig;
+    const builder = config.governanceVoteBuilder;
+    if (!builder) return;
 
     yield* Effect.try({
       try: () => config.txBuilder.add_vote(builder.build()),
       catch: governanceActionError,
     });
-    if (credential?.type === "Script") {
-      config.governanceVoteWitnessKeys.push(cmlVoter.to_canonical_cbor_hex());
-    }
+    config.governanceVoteBuilder = undefined;
   });
 
 export const propose = (

--- a/packages/lucid/test/redeemer-context-internal.test.ts
+++ b/packages/lucid/test/redeemer-context-internal.test.ts
@@ -1347,6 +1347,161 @@ describe("context-dependent redeemers internal coverage", () => {
     ).toBeUndefined();
   });
 
+  test.each([false, true])(
+    "vote accumulates governance actions for the same key DRep with canonical=%s",
+    async (canonical) => {
+      const walletInput = makeRichUtxo(canonical ? "d4" : "d3");
+      const voter = {
+        type: "DRep" as const,
+        credential: { type: "Key" as const, hash: "d4".repeat(28) },
+      };
+      const actions = [
+        {
+          actionId: { txHash: "aa".repeat(32), index: 0n },
+          vote: "Yes" as const,
+          expected: CML.Vote.Yes,
+        },
+        {
+          actionId: { txHash: "bb".repeat(32), index: 1n },
+          vote: "No" as const,
+          expected: CML.Vote.No,
+        },
+        {
+          actionId: { txHash: "cc".repeat(32), index: 2n },
+          vote: "Abstain" as const,
+          expected: CML.Vote.Abstain,
+        },
+      ];
+
+      let builder = makeTxBuilder({
+        ...lucidConfig,
+        wallet: makeWallet([walletInput]),
+      });
+      for (const action of actions) {
+        builder = builder.vote(voter, action.actionId, action.vote);
+      }
+
+      const tx = (
+        await builder.complete({
+          canonical,
+          localUPLCEval: false,
+          presetWalletInputs: [walletInput],
+        })
+      ).toTransaction();
+      const votingProcedures = tx.body().voting_procedures();
+      expect(votingProcedures?.len()).toBe(1);
+
+      const cmlVoter = votingProcedures!.keys().get(0);
+      const actionVotes = votingProcedures!.get(cmlVoter)!;
+      expect(actionVotes.len()).toBe(actions.length);
+
+      const retained = new Map<string, CML.Vote>();
+      for (let index = 0; index < actionVotes.len(); index++) {
+        const actionId = actionVotes.keys().get(index);
+        retained.set(
+          `${actionId.transaction_id().to_hex()}#${actionId.gov_action_index()}`,
+          actionVotes.get(actionId)!.vote(),
+        );
+      }
+      expect(retained).toEqual(
+        new Map(
+          actions.map((action) => [
+            `${action.actionId.txHash}#${action.actionId.index}`,
+            action.expected,
+          ]),
+        ),
+      );
+      expect(tx.witness_set().redeemers()).toBeUndefined();
+    },
+  );
+
+  test("vote accumulates governance actions for the same native-script DRep", async () => {
+    const walletInput = makeRichUtxo("d5");
+    const nativeScript = scriptFromNative({
+      type: "sig",
+      keyHash: "75".repeat(28),
+    });
+    const voter = {
+      type: "DRep" as const,
+      credential: {
+        type: "Script" as const,
+        hash: mintingPolicyToId(nativeScript),
+      },
+    };
+
+    const tx = (
+      await makeTxBuilder({
+        ...lucidConfig,
+        wallet: makeWallet([walletInput]),
+      })
+        .attach.VoteValidator(nativeScript)
+        .vote(voter, { txHash: "76".repeat(32), index: 0n }, "Yes")
+        .vote(voter, { txHash: "77".repeat(32), index: 1n }, "No")
+        .complete({
+          localUPLCEval: false,
+          presetWalletInputs: [walletInput],
+        })
+    ).toTransaction();
+
+    const votingProcedures = tx.body().voting_procedures();
+    expect(votingProcedures?.len()).toBe(1);
+    const cmlVoter = votingProcedures!.keys().get(0);
+    expect(votingProcedures!.get(cmlVoter)?.len()).toBe(2);
+    expect(tx.witness_set().native_scripts()?.len()).toBe(1);
+    expect(tx.witness_set().redeemers()).toBeUndefined();
+  });
+
+  test("vote rejects an exact duplicate voter and governance action", async () => {
+    const walletInput = makeRichUtxo("d6");
+    const voter = {
+      type: "DRep" as const,
+      credential: { type: "Key" as const, hash: "78".repeat(28) },
+    };
+
+    await expect(
+      makeTxBuilder({
+        ...lucidConfig,
+        wallet: makeWallet([walletInput]),
+      })
+        .vote(voter, governanceActionId, "Yes")
+        .vote(voter, governanceActionId, "No")
+        .complete({
+          localUPLCEval: false,
+          presetWalletInputs: [walletInput],
+        }),
+    ).rejects.toThrow(/GovernanceAction:.*Vote already exists/);
+  });
+
+  test("config finalizes accumulated voting procedures on the replayed builder", async () => {
+    const walletInput = makeRichUtxo("d7");
+    const voter = {
+      type: "DRep" as const,
+      credential: { type: "Key" as const, hash: "79".repeat(28) },
+    };
+    const replayedConfig = await makeTxBuilder({
+      ...lucidConfig,
+      wallet: makeWallet([walletInput]),
+    })
+      .collectFrom([walletInput])
+      .vote(voter, { txHash: "7a".repeat(32), index: 0n }, "Yes")
+      .vote(voter, { txHash: "7b".repeat(32), index: 1n }, "No")
+      .config();
+
+    expect(replayedConfig.governanceVoteBuilder).toBeUndefined();
+    replayedConfig.txBuilder.add_change_if_needed(
+      CML.Address.from_bech32(address),
+      false,
+    );
+    const tx = replayedConfig.txBuilder
+      .build(CML.ChangeSelectionAlgo.Default, CML.Address.from_bech32(address))
+      .build_unchecked();
+    const votingProcedures = tx.body().voting_procedures();
+    expect(votingProcedures?.len()).toBe(1);
+    expect(votingProcedures?.get(votingProcedures.keys().get(0))?.len()).toBe(
+      2,
+    );
+  });
+
   test("vote builds committee and stake pool voter procedures without Plutus redeemers", async () => {
     const walletInput = makeRichUtxo("d1");
     const committeeVoter = {
@@ -1538,6 +1693,7 @@ describe("context-dependent redeemers internal coverage", () => {
       .attach.VoteValidator(nativeScript)
       .attach.VoteValidator(alwaysSucceedV3Script)
       .vote(nativeVoter, governanceActionId, "No")
+      .vote(nativeVoter, { ...governanceActionId, index: 1n }, "Abstain")
       .vote(plutusVoter, governanceActionId, "Yes", undefined, stableRedeemer)
       .complete({
         localUPLCEval: false,
@@ -1546,6 +1702,16 @@ describe("context-dependent redeemers internal coverage", () => {
 
     const tx = signBuilder.toTransaction();
     expect(tx.body().voting_procedures()?.len()).toBe(2);
+    const votingProcedures = tx.body().voting_procedures()!;
+    const nativeActionVotes = votingProcedures.get(
+      Array.from({ length: votingProcedures.len() }, (_, index) =>
+        votingProcedures.keys().get(index),
+      ).find(
+        (voter) =>
+          voter.script_hash()?.to_hex() === nativeVoter.credential.hash,
+      )!,
+    );
+    expect(nativeActionVotes?.len()).toBe(2);
     const [redeemer] = canonicalRedeemerEntries(tx.witness_set().redeemers()!);
     expect(redeemer.tag).toBe("vote");
     expect(redeemer.index).toBe(1n);


### PR DESCRIPTION
## Summary

- accumulate repeated `TxBuilder.vote()` calls in one CML `VoteBuilder` result so each voter's governance-action map is preserved
- finalize accumulated votes after action replay/program execution, including the lower-level `.config()` replay path
- surface exact duplicate voter/action pairs as an explicit error while retaining the existing same-voter Plutus redeemer guard
- add a patch changeset for `@lucid-evolution/lucid`

## Testing

- `pnpm --filter @lucid-evolution/lucid test` with live credentials blanked (146 passed, 120 live-only skipped)
- `pnpm --filter @lucid-evolution/lucid lint`
- `pnpm --filter @lucid-evolution/lucid build`
- `pnpm exec turbo test --filter=!@lucid-evolution/lucid`
- built-package Node 24 reproduction with both `canonical: false` and `canonical: true` (1 voter, 3 retained actions)