### PR TITLE
docs: add Nexus provider

### DIFF
--- a/docs/pages/documentation/core-concepts/provider.mdx
+++ b/docs/pages/documentation/core-concepts/provider.mdx
@@ -12,6 +12,7 @@ Lucid Evolution supports several providers:
 - [Koios](./provider/koios.mdx)
 - [YACI DevKit](./provider/yaci-devkit.mdx)
 - [UTxORPC](./provider/utxo-rpc.mdx)
+- [Nexus](./provider/nexus.mdx)
 
 <Callout type="info">
   While a provider is required for blockchain interaction, you can still use transaction building features of the Evolution library without one.

--- a/docs/pages/documentation/core-concepts/provider/_meta.json
+++ b/docs/pages/documentation/core-concepts/provider/_meta.json
@@ -5,5 +5,6 @@
   "koios": "Koios",
   "yaci-devkit": "YACI DevKit",
   "utxo-rpc": "UTxORPC",
+  "nexus": "Nexus",
   "common-queries": "Common Queries"
 }

--- a/docs/pages/documentation/core-concepts/provider/nexus.mdx
+++ b/docs/pages/documentation/core-concepts/provider/nexus.mdx
@@ -1,0 +1,31 @@
+import { Callout } from "nextra/components";
+
+## Nexus
+
+[Nexus](https://nexus.gerowallet.io) is a multi-provider Cardano data API by [Gero](https://gerowallet.io) with automatic failover across chain indexers. The [`@adlabs/nexus`](https://www.npmjs.com/package/@adlabs/nexus) package ships a lucid-evolution provider along with a typed REST client.
+
+```bash
+npm install @adlabs/nexus
+```
+
+Usage example to initialize Lucid with Nexus:
+
+```typescript
+import { Lucid } from "@lucid-evolution/lucid";
+import { NexusProvider } from "@adlabs/nexus/lucid";
+
+const lucid = await Lucid(
+  new NexusProvider({
+    apiKey: "<nexus-api-key>",
+    network: "Preprod", // "Mainnet" | "Preprod" | "Preview"
+  }),
+  "Preprod",
+);
+```
+
+<Callout type="info">
+  Self-hosted deployments can point the provider at their own instance via the
+  optional `baseUrl` option.
+</Callout>
+
+Learn more at: https://github.com/Gero-Labs/nexus-sdk


### PR DESCRIPTION
Adds [Nexus](https://nexus.gerowallet.io) — a multi-provider Cardano data API by Gero — to the providers documentation, following the same pattern as the UTxORPC (external package) entry.

The provider ships in the [`@adlabs/nexus`](https://www.npmjs.com/package/@adlabs/nexus) npm package (`NexusProvider` at the `@adlabs/nexus/lucid` subpath) and implements the full `Provider` interface from `@lucid-evolution/core-types`: utxos (address/credential/unit/outref), protocol parameters, delegation, datums, submit, evaluate, and awaitTx.

Changes:
- new `provider/nexus.mdx` page (install + usage example)
- `_meta.json` nav entry
- provider list entry in `provider.mdx`

Source: https://github.com/Gero-Labs/nexus-sdk