### PR TITLE
[CRITICAL] Fix redeemer builders

### DIFF
--- a/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
+++ b/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
@@ -369,30 +369,44 @@ const completeDelayedFromActions = (
     let previousFingerprint: string | undefined;
 
     for (let attempt = 0; attempt < 8; attempt++) {
-      const replayConfig = makeReplayConfig(sourceConfig);
+      // Build the transaction. When real script evaluation fails — which can
+      // happen when the redeemer was computed from a bootstrap attempt whose
+      // coin selection differed from the real-eval coin selection — fall back to
+      // a fresh bootstrap build so we can still read the correct canonical
+      // ordering and compute an updated redeemer for the next iteration.
+      let activeReplayConfig = makeReplayConfig(sourceConfig);
+      const buildAttempt = (useBootstrap: boolean) => {
+        const cfg = makeReplayConfig(sourceConfig);
+        return pipe(
+          Effect.gen(function* () {
+            yield* replayTxActions(sourceConfig.actions, currentRedeemers);
+            const missingRedeemers = cfg.pendingRedeemers.some(
+              (pending) => !currentRedeemers.has(pending.id),
+            );
+            activeReplayConfig = cfg;
+            return yield* completeCurrentConfig(
+              { ...options, canonical: true },
+              {
+                forceCanonical: true,
+                bootstrapExUnits: missingRedeemers || useBootstrap,
+                walletInputs: fixedWalletInputs,
+              },
+            );
+          }),
+          Effect.provide(Layer.succeed(TxConfig, { config: cfg })),
+        );
+      };
+
       const result = yield* pipe(
-        Effect.gen(function* () {
-          yield* replayTxActions(sourceConfig.actions, currentRedeemers);
-          const missingRedeemers = replayConfig.pendingRedeemers.some(
-            (pending) => !currentRedeemers.has(pending.id),
-          );
-          return yield* completeCurrentConfig(
-            { ...options, canonical: true },
-            {
-              forceCanonical: true,
-              bootstrapExUnits: missingRedeemers,
-              walletInputs: fixedWalletInputs,
-            },
-          );
-        }),
-        Effect.provide(Layer.succeed(TxConfig, { config: replayConfig })),
+        buildAttempt(false),
+        Effect.catchTag('EvaluatorError', () => buildAttempt(true)),
       );
 
       const tx = result[2].toTransaction();
       const allResolvedInputs = [
-        ...replayConfig.walletInputs,
-        ...replayConfig.collectedInputs,
-        ...replayConfig.readInputs,
+        ...activeReplayConfig.walletInputs,
+        ...activeReplayConfig.collectedInputs,
+        ...activeReplayConfig.readInputs,
       ];
       const redeemerInfo = yield* buildCanonicalRedeemerInfo(
         tx,
@@ -400,7 +414,7 @@ const completeDelayedFromActions = (
       );
       const nextRedeemers = yield* buildRedeemersFromCanonicalContext(
         redeemerInfo,
-        replayConfig.pendingRedeemers,
+        activeReplayConfig.pendingRedeemers,
         redeemerBuilderCache,
       );
 

--- a/packages/lucid/src/tx-builder/internal/RedeemerContext.ts
+++ b/packages/lucid/src/tx-builder/internal/RedeemerContext.ts
@@ -18,6 +18,7 @@ import {
   coreToOutRef,
   coreToTxOutput,
   fromCMLRedeemerTag,
+  sortUTxOs,
 } from "@lucid-evolution/utils";
 import { CML } from "../../core.js";
 import { TxBuilderError } from "../../Errors.js";
@@ -227,7 +228,11 @@ export const resolveCanonicalInputs = (
       }
       inputs.push(cloneUTxO(resolved));
     }
-    return inputs;
+    // Sort by the Cardano ledger's Haskell Ord TxIn ordering (TxId bytes
+    // lexicographic, then TxIx numeric). deriveRedeemerPurposes accesses
+    // inputs[redeemer.index] directly, so this array must match the order
+    // the ledger uses when constructing the script context.
+    return sortUTxOs(inputs, "Canonical");
   });
 
 export const resolveCanonicalReferenceInputs = (


### PR DESCRIPTION
## Description

This is an attempt for a fix. There was an unpredictable bug with some Tx building that use Redeemer builders. For some Txs that required index from inputs, it sometimes failed to use correct index, based on some debugging in emulator it seemed to happen inside `completeDelayedFromActions` during attempt 2 of the iteration. The tx was built but it failed with an on-chain error related to inputs ordering, i.e. the execution of the validators to estimate the ex units caused it to fail with outdated redeemers.

EDIT: it's still not appropriate fix, since it doesn't evaluate the TXs in these situations and just uses bootstrap. However, this is at least trying to point to an issue to solve, maybe it brings some light for maintainers about the issue.

## Type of change

- [x] 🔧 Bug fix
- [ ] 💡 New feature
- [ ] 🔩 Performance improvement
- [ ] 📚 Docs

