### PR TITLE
[MAJOR] Fix redeemer builders

### DIFF
--- a/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
+++ b/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
@@ -382,7 +382,12 @@ const completeDelayedFromActions = (
 
           // Pre-add wallet UTxOs selected in the previous attempt so the
           // transaction structure (and therefore redeemer indices) stay
-          // consistent while ex-unit estimates converge.
+          // consistent while ex-unit estimates converge. 
+          // 
+          // NOTE: This is safe as far as the first `attempt` is the only one adding
+          // wallet UTxOs with consideration of highest ex units possible.
+          // Follow up attempts with converging ex-units (decreasing) will not need to 
+          // add any new wallet UTxOs, and therefore will not change the redeemer indices.
           for (const utxo of prevCoinSelectedInputs) {
             if (!replayConfig.collectedInputs.some((c) => isEqualUTxO(c, utxo))) {
               yield* Effect.try({

--- a/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
+++ b/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
@@ -235,6 +235,7 @@ const completeCurrentConfig = (
       false,
       internalOptions.bootstrapExUnits === true,
     );
+
     // Second round of coin selection by including script execution costs in fee estimation.
     // UPLC evaluation need to be performed again if new inputs are selected during coin selection.
     // Because increasing the inputs can increase the script execution budgets.
@@ -367,12 +368,40 @@ const completeDelayedFromActions = (
     let currentRedeemers = new Map<number, string>();
     const redeemerBuilderCache: RedeemerBuilderCache = new Map();
     let previousFingerprint: string | undefined;
+    // Wallet UTxOs that were coin-selected in the previous attempt. Carried
+    // forward so that redeemer indices remain stable across attempts even when
+    // the fee estimate changes (e.g. bootstrap ex-units → real ex-units).
+    let coinSelectedWalletInputs: UTxO[] = [];
 
     for (let attempt = 0; attempt < 8; attempt++) {
       const replayConfig = makeReplayConfig(sourceConfig);
+      const prevCoinSelectedInputs = [...coinSelectedWalletInputs];
       const result = yield* pipe(
         Effect.gen(function* () {
           yield* replayTxActions(sourceConfig.actions, currentRedeemers);
+
+          // Pre-add wallet UTxOs selected in the previous attempt so the
+          // transaction structure (and therefore redeemer indices) stay
+          // consistent while ex-unit estimates converge.
+          for (const utxo of prevCoinSelectedInputs) {
+            if (!replayConfig.collectedInputs.some((c) => isEqualUTxO(c, utxo))) {
+              yield* Effect.try({
+                try: () => {
+                  const input =
+                    CML.SingleInputBuilder.from_transaction_unspent_output(
+                      utxoToCore(utxo),
+                    ).payment_key();
+                  replayConfig.txBuilder.add_input(input);
+                },
+                catch: (error) => completeTxError(error),
+              });
+              replayConfig.collectedInputs = [
+                ...replayConfig.collectedInputs,
+                utxo,
+              ];
+            }
+          }
+
           const missingRedeemers = replayConfig.pendingRedeemers.some(
             (pending) => !currentRedeemers.has(pending.id),
           );
@@ -386,6 +415,12 @@ const completeDelayedFromActions = (
           );
         }),
         Effect.provide(Layer.succeed(TxConfig, { config: replayConfig })),
+      );
+
+      // Capture wallet UTxOs selected via coin selection so they can be
+      // pre-added in the next attempt to keep the transaction structure stable.
+      coinSelectedWalletInputs = replayConfig.collectedInputs.filter((utxo) =>
+        fixedWalletInputs.some((w) => isEqualUTxO(w, utxo)),
       );
 
       const tx = result[2].toTransaction();
@@ -460,7 +495,7 @@ export const selectionAndEvaluation = (
             includeLeftoverLovelaceAsFee,
           )
         : { selected: [], burnable: { lovelace: 0n } };
-
+    
     let estimatedFee = yield* estimateFee(config, script_calculation);
     if (_Array.isEmptyArray(inputsToAdd)) {
       estimatedFee += burnable.lovelace;


### PR DESCRIPTION
## Description

This should fix a nasty bug with the `.complete` function, that occured only occasionally and is hard to reproduce.

The bug happens when using redeemer builders and so inside the logic of `completeDelayedFromActions`. In the first iteration, the logic bootstraps the ex units to be max allowable, that picks wallet UTXOs to cover the tx fee and the redeemers are built using the redeemer builder based on these inputs. In the next iteration, the built redeemers are reused from previous iteration, however the wallet UTXOs picked in first iteration are not reused and the second iteration picks new UTXOs...

This causes the second iteration to fail, because there's mismatch between tx inputs and the indices in redeemers (when using indices for inputs), so the on-chain logic fails because of the mismatch.

## More expressive description of the bug

The bug: Attempt 0 uses bootstrap ex-units (huge fake fee estimate) → coin selection adds wallet UTXO 9ab8c1... → redeemers are built referencing that UTXO at index 4. Attempt 1 switches to real ex-units (smaller fee) → coin selection decides no extra UTXO is needed → the UTXO disappears from the transaction → redeemers reference a missing index → crash.

### Unhandled edge case

When there would a possible attempt 2 (3rd attempt) that adds a UTXO from wallet, there would again be a mismatch of the redeemers causing the tx building to fail.
This is however a very unlikely situation since the inputs there already consider highest ex units possible, so there shouldn't be a situation where there's new input added in 3rd iteration. Added an explanation comment to the code re this.

## The fix

After each attempt: capture which UTxOs came from fixedWalletInputs and ended up in replayConfig.collectedInputs (those are the coin-selected wallet inputs).

At the start of the next attempt: before completeCurrentConfig runs, pre-add those UTxOs directly into replayConfig.collectedInputs and replayConfig.txBuilder. Since they're already in collectedInputs, doCoinSelection subtracts their value from assetsDelta correctly (no double-counting), availableInputs excludes them (no duplicate add_input), but they remain present in the transaction — keeping redeemer indices stable while ex-unit estimates converge.

## The solution

The drawback of the solution is that the balancing can include UTXOs from wallet that the Tx doesn't actually need, this causes slightly higher fee for spending extra UTXO. The UTXO is however only spent and produced again back in the wallet. 
Even for the value of the drawback (I'd say minimal in the bigger picture of all the inefficiencies in Lucid), it solves quite critical issue.


## Type of change

- [x] 🔧 Bug fix
- [ ] 💡 New feature
- [ ] 🔩 Performance improvement
- [ ] 📚 Docs

