### PR TITLE
fix(provider): optimize Kupmios queries and timeouts

### DIFF
--- a/.changeset/quick-kupos-resolve.md
+++ b/.changeset/quick-kupos-resolve.md
@@ -2,4 +2,4 @@
 "@lucid-evolution/provider": patch
 ---
 
-Resolve Kupo datum and script hashes in UTxO match queries and make Kupmios request and confirmation timeouts configurable.
+Resolve Kupo datum and script hashes in UTxO match queries and make Kupmios request and confirmation timeouts configurable. Kupmios now requires Kupo v2.10.0 or later.

--- a/.changeset/quick-kupos-resolve.md
+++ b/.changeset/quick-kupos-resolve.md
@@ -1,0 +1,5 @@
+---
+"@lucid-evolution/provider": patch
+---
+
+Resolve Kupo datum and script hashes in UTxO match queries and make Kupmios request and confirmation timeouts configurable.

--- a/packages/provider/src/internal/kupo.ts
+++ b/packages/provider/src/internal/kupo.ts
@@ -11,28 +11,10 @@ export const ValueSchema = S.Struct({
 });
 export interface Value extends S.Schema.Type<typeof ValueSchema> {}
 
-export const UTxOSchema = S.Struct({
-  transaction_index: S.Number,
-  transaction_id: S.String,
-  output_index: S.Number,
-  address: S.String,
-  value: ValueSchema,
-  datum_hash: S.NullOr(S.String),
-  datum_type: S.optional(S.Literal("hash", "inline")),
-  script_hash: S.NullOr(S.String),
-  created_at: S.Struct({
-    slot_no: S.Number,
-    header_hash: S.String,
-  }),
-  spent_at: S.NullOr(
-    S.Struct({
-      slot_no: S.Number,
-      header_hash: S.String,
-    }),
-  ),
+const PointSchema = S.Struct({
+  slot_no: S.Number,
+  header_hash: S.String,
 });
-
-export interface UTxO extends S.Schema.Type<typeof UTxOSchema> {}
 
 export const ScriptSchema = S.NullOr(
   S.Struct({
@@ -41,6 +23,32 @@ export const ScriptSchema = S.NullOr(
   }),
 );
 export type Script = S.Schema.Type<typeof ScriptSchema>;
+
+const UTxOFields = {
+  transaction_index: S.Number,
+  transaction_id: S.String,
+  output_index: S.Number,
+  address: S.String,
+  value: ValueSchema,
+  datum_hash: S.NullOr(S.String),
+  datum_type: S.optional(S.Literal("hash", "inline")),
+  script_hash: S.NullOr(S.String),
+  created_at: PointSchema,
+  spent_at: S.NullOr(PointSchema),
+};
+
+export const UTxOSchema = S.Struct(UTxOFields);
+
+export interface UTxO extends S.Schema.Type<typeof UTxOSchema> {}
+
+export const ResolvedUTxOSchema = S.Struct({
+  ...UTxOFields,
+  datum: S.NullOr(S.String),
+  script: ScriptSchema,
+});
+
+export interface ResolvedUTxO
+  extends S.Schema.Type<typeof ResolvedUTxOSchema> {}
 
 export const DatumSchema = S.NullOr(S.Struct({ datum: S.String }));
 

--- a/packages/provider/src/kupmios.ts
+++ b/packages/provider/src/kupmios.ts
@@ -31,6 +31,25 @@ import { KupmiosError, toKupmiosError } from "./errors.js";
 
 export { KupmiosError } from "./errors.js";
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const DEFAULT_AWAIT_TX_TIMEOUT_MS = 160_000;
+
+export interface KupmiosOptions {
+  readonly ogmiosHeader?: Record<string, string>;
+  readonly kupoHeader?: Record<string, string>;
+  /** One-shot Kupo and Ogmios request deadline in milliseconds. @default 30000 */
+  readonly requestTimeoutMs?: number;
+  /** Overall transaction confirmation deadline in milliseconds. @default 160000 */
+  readonly awaitTxTimeoutMs?: number;
+}
+
+const validateTimeout = (name: string, timeout: number): number => {
+  if (!Number.isFinite(timeout) || timeout <= 0) {
+    throw new TypeError(`${name} must be a positive finite number.`);
+  }
+  return timeout;
+};
+
 const catchProviderError =
   (protocol: "kupo" | "ogmios", operation: string) =>
   <A, E, R>(
@@ -95,22 +114,26 @@ const runProviderEffect = async <A>(
 export class Kupmios implements Provider {
   private readonly kupoUrl: string;
   private readonly ogmiosUrl: string;
-  private readonly headers?: {
-    readonly ogmiosHeader?: Record<string, string>;
-    readonly kupoHeader?: Record<string, string>;
-  };
+  private readonly options: KupmiosOptions;
+  private readonly requestTimeoutMs: number;
+  private readonly awaitTxTimeoutMs: number;
 
   constructor(
     kupoUrl: string,
     ogmiosUrl: string,
-    headers?: {
-      ogmiosHeader?: Record<string, string>;
-      kupoHeader?: Record<string, string>;
-    },
+    options: KupmiosOptions = {},
   ) {
     this.kupoUrl = kupoUrl;
     this.ogmiosUrl = ogmiosUrl;
-    this.headers = headers;
+    this.options = options;
+    this.requestTimeoutMs = validateTimeout(
+      "requestTimeoutMs",
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+    );
+    this.awaitTxTimeoutMs = validateTimeout(
+      "awaitTxTimeoutMs",
+      options.awaitTxTimeoutMs ?? DEFAULT_AWAIT_TX_TIMEOUT_MS,
+    );
   }
 
   async getProtocolParameters(): Promise<ProtocolParameters> {
@@ -129,9 +152,9 @@ export class Kupmios implements Provider {
           this.ogmiosUrl,
           data,
           schema,
-          this.headers?.ogmiosHeader,
+          this.options.ogmiosHeader,
         ),
-        Effect.timeout(10_000),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("ogmios", "queryLedgerState/protocolParameters"),
         Effect.provide(FetchHttpClient.layer),
       ),
@@ -165,9 +188,9 @@ export class Kupmios implements Provider {
           this.ogmiosUrl,
           data,
           schema,
-          this.headers?.ogmiosHeader,
+          this.options.ogmiosHeader,
         ),
-        Effect.timeout(10_000),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("ogmios", "queryLedgerState/treasuryAndReserves"),
         Effect.provide(FetchHttpClient.layer),
       ),
@@ -187,15 +210,13 @@ export class Kupmios implements Provider {
     const queryPredicate = isAddress
       ? addressOrCredential
       : addressOrCredential.hash;
-    const pattern = `${this.kupoUrl}/matches/${queryPredicate}${isAddress ? "" : "/*"}?unspent`;
-    const schema = S.Array(Kupo.UTxOSchema);
+    const pattern = `${this.kupoUrl}/matches/${queryPredicate}${isAddress ? "" : "/*"}?unspent&resolve_hashes`;
+    const schema = S.Array(Kupo.ResolvedUTxOSchema);
     const utxos = await runProviderEffect(
       pipe(
-        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-        Effect.flatMap((u) =>
-          kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
-        ),
-        Effect.timeout(10_000),
+        HttpUtils.makeGet(pattern, schema, this.options.kupoHeader),
+        Effect.map(kupmiosUtxosToUtxos),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("kupo", "getUtxos"),
         Effect.provide(FetchHttpClient.layer),
       ),
@@ -214,15 +235,13 @@ export class Kupmios implements Provider {
       ? addressOrCredential
       : addressOrCredential.hash;
     const { policyId, assetName } = fromUnit(unit);
-    const pattern = `${this.kupoUrl}/matches/${queryPredicate}${isAddress ? "" : "/*"}?unspent&policy_id=${policyId}${assetName ? `&asset_name=${assetName}` : ""}`;
-    const schema = S.Array(Kupo.UTxOSchema);
+    const pattern = `${this.kupoUrl}/matches/${queryPredicate}${isAddress ? "" : "/*"}?unspent&resolve_hashes&policy_id=${policyId}${assetName ? `&asset_name=${assetName}` : ""}`;
+    const schema = S.Array(Kupo.ResolvedUTxOSchema);
     const utxos = await runProviderEffect(
       pipe(
-        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-        Effect.flatMap((u) =>
-          kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
-        ),
-        Effect.timeout(10_000),
+        HttpUtils.makeGet(pattern, schema, this.options.kupoHeader),
+        Effect.map(kupmiosUtxosToUtxos),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("kupo", "getUtxosWithUnit"),
         Effect.provide(FetchHttpClient.layer),
       ),
@@ -249,15 +268,13 @@ export class Kupmios implements Provider {
     const queryPredicate = isAddress
       ? addressOrCredential
       : addressOrCredential.hash;
-    const pattern = `${this.kupoUrl}/matches/${queryPredicate}${isAddress ? "" : "/*"}?unspent&policy_id=${normalizedPolicyId}`;
-    const schema = S.Array(Kupo.UTxOSchema);
+    const pattern = `${this.kupoUrl}/matches/${queryPredicate}${isAddress ? "" : "/*"}?unspent&resolve_hashes&policy_id=${normalizedPolicyId}`;
+    const schema = S.Array(Kupo.ResolvedUTxOSchema);
     return runProviderEffect(
       pipe(
-        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-        Effect.flatMap((utxos) =>
-          kupmiosUtxosToUtxos(this.kupoUrl, utxos, this.headers?.kupoHeader),
-        ),
-        Effect.timeout(10_000),
+        HttpUtils.makeGet(pattern, schema, this.options.kupoHeader),
+        Effect.map(kupmiosUtxosToUtxos),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("kupo", "getUtxosWithPolicy"),
         Effect.provide(FetchHttpClient.layer),
       ),
@@ -268,15 +285,13 @@ export class Kupmios implements Provider {
 
   async getUtxoByUnit(unit: Unit): Promise<UTxO> {
     const { policyId, assetName } = fromUnit(unit);
-    const pattern = `${this.kupoUrl}/matches/${policyId}.${assetName ?? ""}?unspent`;
-    const schema = S.Array(Kupo.UTxOSchema);
+    const pattern = `${this.kupoUrl}/matches/${policyId}.${assetName ?? ""}?unspent&resolve_hashes`;
+    const schema = S.Array(Kupo.ResolvedUTxOSchema);
     const utxos = await runProviderEffect(
       pipe(
-        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-        Effect.flatMap((u) =>
-          kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
-        ),
-        Effect.timeout(10_000),
+        HttpUtils.makeGet(pattern, schema, this.options.kupoHeader),
+        Effect.map(kupmiosUtxosToUtxos),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("kupo", "getUtxoByUnit"),
         Effect.provide(FetchHttpClient.layer),
       ),
@@ -298,15 +313,13 @@ export class Kupmios implements Provider {
       ...new Set(outRefs.map((outRef) => outRef.txHash)),
     ];
     const mkPattern = (txHash: string) =>
-      `${this.kupoUrl}/matches/*@${txHash}?unspent`;
-    const schema = S.Array(Kupo.UTxOSchema);
+      `${this.kupoUrl}/matches/*@${txHash}?unspent&resolve_hashes`;
+    const schema = S.Array(Kupo.ResolvedUTxOSchema);
     const program = Effect.forEach(queryHashes, (txHash) =>
       pipe(
-        HttpUtils.makeGet(mkPattern(txHash), schema, this.headers?.kupoHeader),
-        Effect.flatMap((u) =>
-          kupmiosUtxosToUtxos(this.kupoUrl, u, this.headers?.kupoHeader),
-        ),
-        Effect.timeout(10_000),
+        HttpUtils.makeGet(mkPattern(txHash), schema, this.options.kupoHeader),
+        Effect.map(kupmiosUtxosToUtxos),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("kupo", "getUtxosByOutRef"),
       ),
     );
@@ -343,10 +356,10 @@ export class Kupmios implements Provider {
           this.ogmiosUrl,
           data,
           schema,
-          this.headers?.ogmiosHeader,
+          this.options.ogmiosHeader,
         ),
         Effect.provide(FetchHttpClient.layer),
-        Effect.timeout(10_000),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("ogmios", "queryLedgerState/rewardAccountSummaries"),
       ),
       "ogmios",
@@ -371,9 +384,9 @@ export class Kupmios implements Provider {
     const schema = Kupo.DatumSchema;
     const result = await runProviderEffect(
       pipe(
-        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
+        HttpUtils.makeGet(pattern, schema, this.options.kupoHeader),
         Effect.provide(FetchHttpClient.layer),
-        Effect.timeout(10_000),
+        Effect.timeout(this.requestTimeoutMs),
         Effect.flatMap(Effect.fromNullable),
         catchProviderError("kupo", "getDatum"),
       ),
@@ -393,8 +406,8 @@ export class Kupmios implements Provider {
     });
     const matches = await runProviderEffect(
       pipe(
-        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
-        Effect.timeout(10_000),
+        HttpUtils.makeGet(pattern, schema, this.options.kupoHeader),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("kupo", "getTransactionStatus"),
         Effect.provide(FetchHttpClient.layer),
       ),
@@ -425,13 +438,13 @@ export class Kupmios implements Provider {
 
     const result = await runProviderEffect(
       pipe(
-        HttpUtils.makeGet(pattern, schema, this.headers?.kupoHeader),
+        HttpUtils.makeGet(pattern, schema, this.options.kupoHeader),
         Effect.provide(FetchHttpClient.layer),
         Effect.repeat({
           schedule: Schedule.exponential(checkInterval),
           until: (result) => result.length > 0,
         }),
-        Effect.timeout(160_000),
+        Effect.timeout(this.awaitTxTimeoutMs),
         catchProviderError("kupo", "awaitTx"),
         Effect.as(true),
       ),
@@ -463,10 +476,10 @@ export class Kupmios implements Provider {
           this.ogmiosUrl,
           data,
           schema,
-          this.headers?.ogmiosHeader,
+          this.options.ogmiosHeader,
         ),
         Effect.provide(FetchHttpClient.layer),
-        Effect.timeout(10_000),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("ogmios", "submitTransaction"),
       ),
       "ogmios",
@@ -505,10 +518,10 @@ export class Kupmios implements Provider {
           this.ogmiosUrl,
           data,
           schema,
-          this.headers?.ogmiosHeader,
+          this.options.ogmiosHeader,
         ),
         Effect.provide(FetchHttpClient.layer),
-        Effect.timeout(10_000),
+        Effect.timeout(this.requestTimeoutMs),
         catchProviderError("ogmios", "evaluateTransaction"),
       ),
       "ogmios",
@@ -532,72 +545,6 @@ export class Kupmios implements Provider {
     return evalRedeemers;
   }
 }
-
-const getDatumEffect = (
-  kupoUrl: string,
-  datum_type: Kupo.UTxO["datum_type"],
-  datum_hash: Kupo.UTxO["datum_hash"],
-  kupoHeader?: Record<string, string>,
-) =>
-  Effect.gen(function* () {
-    if (datum_type === "inline" && datum_hash) {
-      const pattern = `${kupoUrl}/datums/${datum_hash}`;
-      const schema = Kupo.DatumSchema;
-      return yield* pipe(
-        HttpUtils.makeGet(pattern, schema, kupoHeader),
-        Effect.flatMap(Effect.fromNullable),
-        Effect.map((result) => result.datum),
-        Effect.retry(
-          Schedule.compose(Schedule.exponential(50), Schedule.recurs(5)),
-        ),
-        Effect.timeout(5_000),
-      );
-    } else return undefined;
-  });
-
-const getScriptEffect = (
-  kupoUrl: string,
-  script_hash: Kupo.UTxO["script_hash"],
-  kupoHeader?: Record<string, string>,
-) =>
-  Effect.gen(function* () {
-    if (script_hash) {
-      const pattern = `${kupoUrl}/scripts/${script_hash}`;
-      const schema = Kupo.ScriptSchema;
-      return yield* pipe(
-        HttpUtils.makeGet(pattern, schema, kupoHeader),
-        Effect.flatMap(Effect.fromNullable),
-        Effect.retry(
-          Schedule.compose(Schedule.exponential(50), Schedule.recurs(5)),
-        ),
-        Effect.timeout(5_000),
-        Effect.map(({ language, script }) => {
-          switch (language) {
-            case "native":
-              return {
-                type: "Native",
-                script: script,
-              } satisfies Script;
-            case "plutus:v1":
-              return {
-                type: "PlutusV1",
-                script: applyDoubleCborEncoding(script),
-              } satisfies Script;
-            case "plutus:v2":
-              return {
-                type: "PlutusV2",
-                script: applyDoubleCborEncoding(script),
-              } satisfies Script;
-            case "plutus:v3":
-              return {
-                type: "PlutusV3",
-                script: applyDoubleCborEncoding(script),
-              } satisfies Script;
-          }
-        }),
-      );
-    } else return undefined;
-  });
 
 const toAssets = (value: Kupo.UTxO["value"]): Assets => {
   const assets: Assets = { lovelace: BigInt(value.coins) };
@@ -665,34 +612,40 @@ const toRewardAccountState = (
   };
 };
 
-const kupmiosUtxosToUtxos = (
-  kupoURL: string,
-  utxos: ReadonlyArray<Kupo.UTxO>,
-  kupoHeader?: Record<string, string>,
-) =>
-  Effect.forEach(
-    utxos,
-    (utxo) => {
-      return pipe(
-        Effect.all([
-          getDatumEffect(kupoURL, utxo.datum_type, utxo.datum_hash, kupoHeader),
-          getScriptEffect(kupoURL, utxo.script_hash, kupoHeader),
-        ]),
-        Effect.map(
-          ([datum, script]): UTxO => ({
-            txHash: utxo.transaction_id,
-            outputIndex: utxo.output_index,
-            address: utxo.address,
-            assets: toAssets(utxo.value),
-            datumHash: utxo.datum_type === "hash" ? utxo.datum_hash : undefined,
-            datum: datum,
-            scriptRef: script,
-          }),
-        ),
-      );
-    },
-    { concurrency: "unbounded" },
-  );
+const toScriptRef = (script: Kupo.Script): Script | undefined => {
+  if (!script) return undefined;
+
+  switch (script.language) {
+    case "native":
+      return { type: "Native", script: script.script };
+    case "plutus:v1":
+      return {
+        type: "PlutusV1",
+        script: applyDoubleCborEncoding(script.script),
+      };
+    case "plutus:v2":
+      return {
+        type: "PlutusV2",
+        script: applyDoubleCborEncoding(script.script),
+      };
+    case "plutus:v3":
+      return {
+        type: "PlutusV3",
+        script: applyDoubleCborEncoding(script.script),
+      };
+  }
+};
+
+const kupmiosUtxosToUtxos = (utxos: ReadonlyArray<Kupo.ResolvedUTxO>): UTxO[] =>
+  utxos.map((utxo) => ({
+    txHash: utxo.transaction_id,
+    outputIndex: utxo.output_index,
+    address: utxo.address,
+    assets: toAssets(utxo.value),
+    datumHash: utxo.datum_type === "hash" ? utxo.datum_hash : undefined,
+    datum: utxo.datum_type === "inline" ? utxo.datum : undefined,
+    scriptRef: toScriptRef(utxo.script),
+  }));
 
 const mkWebSocket = async (url: string, data: unknown): Promise<WebSocket> => {
   const client = new WebSocket(url);

--- a/packages/provider/src/kupmios.ts
+++ b/packages/provider/src/kupmios.ts
@@ -84,6 +84,8 @@ const runProviderEffect = async <A>(
 /**
  * Provides support for interacting with both Kupo and Ogmios APIs.
  *
+ * Requires Kupo v2.10.0 or later.
+ *
  * @example Using Local URLs (No Authentication):
  * ```typescript
  * const kupmios = new Kupmios(

--- a/packages/provider/test/kupmios-errors.test.ts
+++ b/packages/provider/test/kupmios-errors.test.ts
@@ -146,17 +146,19 @@ describe("Kupmios structured errors", () => {
     });
   });
 
-  test("classifies provider operation deadlines as retryable timeouts", async () => {
+  test("honors configured request deadlines", async () => {
     vi.useFakeTimers();
     vi.spyOn(globalThis, "fetch").mockImplementation(
       async () => await new Promise<Response>(() => undefined),
     );
-    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test", {
+      requestTimeoutMs: 25,
+    });
 
     const result = provider
       .getTransactionStatus(txHash)
       .catch((cause) => cause);
-    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(25);
     const error = await result;
 
     expect(error).toBeInstanceOf(KupmiosError);
@@ -167,6 +169,62 @@ describe("Kupmios structured errors", () => {
       retryable: true,
     });
     expect(error.cause).toBeDefined();
+  });
+
+  test("defaults request deadlines to 30 seconds", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => await new Promise<Response>(() => undefined),
+    );
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const result = provider
+      .getTransactionStatus(txHash)
+      .catch((cause) => cause);
+    await vi.advanceTimersByTimeAsync(30_000);
+    const error = await result;
+
+    expect(error).toMatchObject({
+      protocol: "kupo",
+      operation: "getTransactionStatus",
+      kind: "timeout",
+    });
+  });
+
+  test("uses an independent configured deadline for awaitTx", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () => await new Promise<Response>(() => undefined),
+    );
+    const provider = new Kupmios("http://kupo.test", "http://ogmios.test", {
+      requestTimeoutMs: 25,
+      awaitTxTimeoutMs: 40,
+    });
+
+    const result = provider.awaitTx(txHash).catch((cause) => cause);
+    await vi.advanceTimersByTimeAsync(40);
+    const error = await result;
+
+    expect(error).toBeInstanceOf(KupmiosError);
+    expect(error).toMatchObject({
+      protocol: "kupo",
+      operation: "awaitTx",
+      kind: "timeout",
+      retryable: true,
+    });
+  });
+
+  test.each([
+    ["requestTimeoutMs", 0],
+    ["requestTimeoutMs", Number.POSITIVE_INFINITY],
+    ["awaitTxTimeoutMs", -1],
+  ] as const)("rejects invalid %s values", (name, value) => {
+    expect(
+      () =>
+        new Kupmios("http://kupo.test", "http://ogmios.test", {
+          [name]: value,
+        }),
+    ).toThrow(`${name} must be a positive finite number.`);
   });
 
   test("turns AbortSignal cancellation into a normal typed Error", async () => {

--- a/packages/provider/test/kupo-schema.test.ts
+++ b/packages/provider/test/kupo-schema.test.ts
@@ -1,9 +1,15 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { Schema as S } from "effect";
 import { Kupmios } from "../src/kupmios.js";
-import { ValueSchema } from "../src/internal/kupo.js";
+import {
+  ResolvedUTxOSchema,
+  UTxOSchema,
+  ValueSchema,
+} from "../src/internal/kupo.js";
 
 const decodeValue = S.decodeUnknownSync(ValueSchema);
+const decodeUtxo = S.decodeUnknownSync(UTxOSchema);
+const decodeResolvedUtxo = S.decodeUnknownSync(ResolvedUTxOSchema);
 const assetUnit =
   "0123456789abcdef0123456789abcdef0123456789abcdef01234567.4c75636964";
 
@@ -19,7 +25,9 @@ const kupoUtxo = (coins: number | string) => ({
     assets: {},
   },
   datum_hash: null,
+  datum: null,
   script_hash: null,
+  script: null,
   created_at: {
     slot_no: 1,
     header_hash:
@@ -89,7 +97,47 @@ describe("Kupo ValueSchema", () => {
   });
 });
 
+describe("Kupo UTxO schemas", () => {
+  test("keeps resolved fields required only in resolved responses", () => {
+    const { datum: _datum, script: _script, ...unresolved } = kupoUtxo(1);
+
+    expect(() => decodeUtxo(unresolved)).not.toThrow();
+    expect(() => decodeResolvedUtxo(unresolved)).toThrow();
+    expect(() => decodeResolvedUtxo(kupoUtxo(1))).not.toThrow();
+  });
+});
+
 describe("Kupmios Kupo quantity decoding", () => {
+  test("requests resolved hashes for every UTxO query", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      async () =>
+        new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const kupmios = new Kupmios("http://kupo.test", "http://ogmios.test");
+    const address = kupoUtxo(1).address;
+    const unit = assetUnit.replace(".", "");
+    const txHash = "0".repeat(64);
+    const queries = [
+      () => kupmios.getUtxos(address),
+      () => kupmios.getUtxosWithUnit(address, unit),
+      () => kupmios.getUtxosWithPolicy(address, unit.slice(0, 56)),
+      () => kupmios.getUtxoByUnit(unit).catch(() => undefined),
+      () => kupmios.getUtxosByOutRef([{ txHash, outputIndex: 0 }]),
+    ];
+
+    for (const query of queries) {
+      fetchSpy.mockClear();
+      await query();
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const url = new URL(getUrl(fetchSpy.mock.calls[0]![0]));
+      expect(url.searchParams.has("resolve_hashes")).toBe(true);
+    }
+  });
+
   test("getUtxos accepts string coins from Kupo", async () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify([kupoUtxo("9909659524")]), {
@@ -104,45 +152,32 @@ describe("Kupmios Kupo quantity decoding", () => {
     );
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = new URL(getUrl(fetchSpy.mock.calls[0]![0]));
+    expect(url.searchParams.has("unspent")).toBe(true);
+    expect(url.searchParams.has("resolve_hashes")).toBe(true);
     expect(utxos).toHaveLength(1);
     expect(utxos[0]?.assets.lovelace).toBe(9909659524n);
   });
 
-  test("forwards Kupo headers to datum and script lookups", async () => {
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
-      .mockImplementation(async (input) => {
-        const url = getUrl(input);
-        if (url === "http://kupo.test/datums/abcd") {
-          return new Response(JSON.stringify({ datum: "d87980" }), {
-            status: 200,
-            headers: { "content-type": "application/json" },
-          });
-        }
-        if (url === "http://kupo.test/scripts/beef") {
-          return new Response(
-            JSON.stringify({ language: "native", script: "00" }),
-            {
-              status: 200,
-              headers: { "content-type": "application/json" },
-            },
-          );
-        }
-        return new Response(
-          JSON.stringify([
-            {
-              ...kupoUtxo("9909659524"),
-              datum_hash: "abcd",
-              datum_type: "inline",
-              script_hash: "beef",
-            },
-          ]),
+  test("resolves datum and script in a single authenticated request", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([
           {
-            status: 200,
-            headers: { "content-type": "application/json" },
+            ...kupoUtxo("9909659524"),
+            datum_hash: "abcd",
+            datum_type: "inline",
+            datum: "d87980",
+            script_hash: "beef",
+            script: { language: "native", script: "00" },
           },
-        );
-      });
+        ]),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    );
     const kupmios = new Kupmios("http://kupo.test", "http://ogmios.test", {
       kupoHeader: { "dmtr-api-key": "secret" },
     });
@@ -156,11 +191,39 @@ describe("Kupmios Kupo quantity decoding", () => {
       type: "Native",
       script: "00",
     });
-    expect(
-      fetchSpy.mock.calls.every(
-        ([input, init]) => getHeader(input, init, "dmtr-api-key") === "secret",
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [input, init] = fetchSpy.mock.calls[0]!;
+    expect(new URL(getUrl(input)).searchParams.has("resolve_hashes")).toBe(
+      true,
+    );
+    expect(getHeader(input, init, "dmtr-api-key")).toBe("secret");
+  });
+
+  test("keeps resolved hash datums represented by datumHash", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(
+        JSON.stringify([
+          {
+            ...kupoUtxo("9909659524"),
+            datum_hash: "abcd",
+            datum_type: "hash",
+            datum: "d87980",
+          },
+        ]),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
       ),
-    ).toBe(true);
+    );
+    const kupmios = new Kupmios("http://kupo.test", "http://ogmios.test");
+
+    const [utxo] = await kupmios.getUtxos(
+      "addr_test1qrngfyc452vy4twdrepdjc50d4kvqutgt0hs9w6j2qhcdjfx0gpv7rsrjtxv97rplyz3ymyaqdwqa635zrcdena94ljs0xy950",
+    );
+
+    expect(utxo?.datumHash).toBe("abcd");
+    expect(utxo?.datum).toBeUndefined();
   });
 
   test("getUtxoByUnit rejects when Kupo returns no UTxOs", async () => {

--- a/packages/provider/test/provider-capabilities.test.ts
+++ b/packages/provider/test/provider-capabilities.test.ts
@@ -246,7 +246,9 @@ describe("Kupmios policy fast path", () => {
       address: "addr_test1query",
       value: { coins: "2000000", assets: { [`${policyId}.`]: "1" } },
       datum_hash: null,
+      datum: null,
       script_hash: null,
+      script: null,
       created_at: { slot_no: 123, header_hash: "b".repeat(64) },
       spent_at: null,
     };
@@ -269,7 +271,7 @@ describe("Kupmios policy fast path", () => {
       { txHash: emptyNameMatch.transaction_id, outputIndex: 0 },
     ]);
     expect(String(fetch.mock.calls[0]?.[0])).toBe(
-      `http://kupo.test/matches/addr_test1query?unspent&policy_id=${policyId}`,
+      `http://kupo.test/matches/addr_test1query?unspent&resolve_hashes&policy_id=${policyId}`,
     );
 
     fetch.mockClear();
@@ -279,7 +281,7 @@ describe("Kupmios policy fast path", () => {
       outputIndex: 0,
     });
     expect(String(fetch.mock.calls[0]?.[0])).toBe(
-      `http://kupo.test/matches/${policyId}.?unspent`,
+      `http://kupo.test/matches/${policyId}.?unspent&resolve_hashes`,
     );
   });
 
@@ -294,7 +296,7 @@ describe("Kupmios policy fast path", () => {
       provider.getUtxosWithPolicy("addr_test1query", policyId),
     ).resolves.toEqual([]);
     expect(String(fetch.mock.calls[0]?.[0])).toBe(
-      `http://kupo.test/matches/addr_test1query?unspent&policy_id=${policyId.toLowerCase()}`,
+      `http://kupo.test/matches/addr_test1query?unspent&resolve_hashes&policy_id=${policyId.toLowerCase()}`,
     );
   });
 


### PR DESCRIPTION
## Summary

- resolve Kupo datum and script hashes directly in UTxO match queries
- model resolved and unresolved Kupo responses with separate schemas built from shared fields
- make Kupmios request and transaction-confirmation timeouts configurable
- preserve existing datum and reference-script conversion behavior

## Root cause

Kupmios fetched UTxOs from `/matches`, then issued separate datum and reference-script requests for every matching output. Large queries therefore produced substantial request fan-out while the whole operation remained constrained by hardcoded deadlines.

Kupo v2.10 supports `resolve_hashes`, allowing the match response to include the associated datum and script in the original request.

## Validation

- `pnpm --filter @lucid-evolution/provider test` — 75 passed, 42 credential-gated tests skipped
- `pnpm --filter @lucid-evolution/provider build`
- Prettier and `git diff --check`

Closes #720
