### PR TITLE
fix: free CML objects explicitly instead of waiting for the finalizer

### DIFF
--- a/.changeset/quiet-cml-explicit-free.md
+++ b/.changeset/quiet-cml-explicit-free.md
@@ -1,0 +1,10 @@
+---
+"@lucid-evolution/core-utils": patch
+"@lucid-evolution/utils": patch
+"@lucid-evolution/plutus": patch
+"@lucid-evolution/lucid": patch
+"@lucid-evolution/provider": patch
+"@lucid-evolution/wallet": patch
+---
+
+Free the CML wasm objects that transaction building, signing, UTxO conversion, Plutus data serialization, seed-wallet derivation and the emulator create internally instead of leaving them to the wasm-bindgen finalizer. Long-running processes that build many transactions no longer grow the CML wasm memory by hundreds of megabytes before a major GC happens to run the finalizers. Adds `withCMLScope` and `freeCML` to `@lucid-evolution/core-utils`. The emulator's `evaluateTx` now reads the redeemer index with `key.index()` instead of `Number(key.index)`.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,6 +10,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # The on-chain tests in packages/lucid spend from one shared preprod wallet
+    # (VITE_WALLET_SEED_2). Two runs building transactions from the same UTxO
+    # set at the same time spend each other's inputs, and every submission then
+    # fails with "All inputs are spent" until the other run is done. Queue runs
+    # of this job instead of letting them race.
+    concurrency:
+      group: preprod-test-wallet
+      cancel-in-progress: false
     env:
       TURBO_SCM_BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
       VITE_BLOCKFROST_KEY: ${{ secrets.VITE_BLOCKFROST_KEY }}

--- a/packages/core-utils/src/cml-scope.ts
+++ b/packages/core-utils/src/cml-scope.ts
@@ -1,0 +1,61 @@
+/**
+ * Explicit ownership for CML (cardano-multiplatform-lib) objects.
+ *
+ * Every CML value is a wasm-bindgen wrapper around an allocation in the CML
+ * wasm linear memory. That allocation is only returned to the allocator when
+ * `free()` runs, either explicitly or from the FinalizationRegistry cleanup
+ * that follows a *major* JavaScript garbage collection. The wrappers
+ * themselves are tiny, so the JavaScript heap stays small and V8 rarely runs a
+ * major collection, while the wasm arena keeps the full size of every
+ * transaction, output, script and datum that was ever decoded. In long-lived
+ * processes, and in test suites that build many transactions per process,
+ * this shows up as steadily growing external memory and, once it exceeds
+ * V8's external-memory limit, as a full compacting GC on almost every
+ * allocation.
+ *
+ * Conventions:
+ * - a function frees every CML object it created and does not return;
+ * - CML arguments are borrowed: CML clones whatever it keeps, so the caller
+ *   may free an argument as soon as the call returns;
+ * - a returned CML object belongs to the caller.
+ *
+ * `withCMLScope` keeps that tidy in code that creates a chain of temporaries.
+ */
+export interface CMLFreeable {
+  free(): void;
+}
+
+/**
+ * Registers a CML temporary with the enclosing `withCMLScope` and returns it.
+ * `undefined` passes through so optional CML getters can be registered
+ * directly.
+ */
+export type CMLOwn = <T extends CMLFreeable | undefined>(object: T) => T;
+
+/**
+ * Runs `body` with an `own` function that registers CML temporaries. Every
+ * registered object is freed when `body` returns or throws, in reverse order
+ * of registration. The value `body` returns is never freed, so return only
+ * objects that were not registered.
+ */
+export const withCMLScope = <T>(body: (own: CMLOwn) => T): T => {
+  const owned: CMLFreeable[] = [];
+  const own: CMLOwn = (object) => {
+    if (object !== undefined) owned.push(object);
+    return object;
+  };
+  try {
+    return body(own);
+  } finally {
+    for (let i = owned.length - 1; i >= 0; i--) owned[i].free();
+  }
+};
+
+/** Frees every defined object in `objects`. */
+export const freeCML = (
+  ...objects: ReadonlyArray<CMLFreeable | undefined | null>
+): void => {
+  // Helpers that return their input unchanged (no redeemers to rewrite, for
+  // example) let the same object arrive twice; free each one once.
+  for (const object of new Set(objects)) object?.free();
+};

--- a/packages/core-utils/src/index.ts
+++ b/packages/core-utils/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./core-utils.js";
+export * from "./cml-scope.js";

--- a/packages/lucid/src/script-context/ScriptContext.ts
+++ b/packages/lucid/src/script-context/ScriptContext.ts
@@ -12,9 +12,11 @@ import {
   validatorToScriptHash,
 } from "@lucid-evolution/utils";
 import { CML } from "../core.js";
+import { withCMLScope } from "@lucid-evolution/core-utils";
 import {
   buildCanonicalRedeemerInfo,
   canonicalRedeemerEntries,
+  freeCanonicalRedeemerEntries,
   proposalProcedureForRedeemerIndex,
   type CanonicalRedeemerEntry,
   type CanonicalRedeemerInfo,
@@ -1013,7 +1015,7 @@ const redeemersFromWitnessSet = (
   redeemerByPurpose: Map<string, PlutusDataValue>;
   purposesByKey: Map<string, ScriptPurposeData>;
 } => {
-  const redeemers = tx.witness_set().redeemers();
+  const redeemers = withCMLScope((own) => own(tx.witness_set()).redeemers());
   if (!redeemers) {
     return {
       redeemerMap: new Map(),
@@ -1021,10 +1023,17 @@ const redeemersFromWitnessSet = (
       purposesByKey: new Map(),
     };
   }
-  const entries = canonicalRedeemerEntries(redeemers).map((entry) => {
-    const purpose = purposeFromRedeemerEntry(entry, info, tx);
-    return [purpose, datumFromPlutusData(entry.data)] as const;
-  });
+  const cmlEntries = canonicalRedeemerEntries(redeemers);
+  let entries;
+  try {
+    entries = cmlEntries.map((entry) => {
+      const purpose = purposeFromRedeemerEntry(entry, info, tx);
+      return [purpose, datumFromPlutusData(entry.data)] as const;
+    });
+  } finally {
+    freeCanonicalRedeemerEntries(cmlEntries);
+    redeemers.free();
+  }
   const sortedEntries = [...entries].sort(([left], [right]) =>
     compareScriptPurpose(left, right),
   );

--- a/packages/lucid/src/tx-builder/internal/Attach.ts
+++ b/packages/lucid/src/tx-builder/internal/Attach.ts
@@ -9,34 +9,40 @@ import {
   WithdrawalValidator,
 } from "@lucid-evolution/core-types";
 import { CML } from "../../core.js";
+import { withCMLScope } from "@lucid-evolution/core-utils";
+
+const scriptHashHex = (script: {
+  hash(): CML.ScriptHash;
+  free(): void;
+}): string => withCMLScope((own) => own(own(script).hash()).to_hex());
 
 export const attachScript = ({ type, script }: Validator) => {
   //TODO: script should be a branded type
   switch (type) {
     case "Native":
       return {
-        key: CML.NativeScript.from_cbor_hex(script).hash().to_hex(),
+        key: scriptHashHex(CML.NativeScript.from_cbor_hex(script)),
         value: { type, script },
       };
     case "PlutusV1":
       return {
-        key: CML.PlutusV1Script.from_cbor_hex(applyDoubleCborEncoding(script))
-          .hash()
-          .to_hex(),
+        key: scriptHashHex(
+          CML.PlutusV1Script.from_cbor_hex(applyDoubleCborEncoding(script)),
+        ),
         value: { type, script: applyDoubleCborEncoding(script) },
       };
     case "PlutusV2":
       return {
-        key: CML.PlutusV2Script.from_cbor_hex(applyDoubleCborEncoding(script))
-          .hash()
-          .to_hex(),
+        key: scriptHashHex(
+          CML.PlutusV2Script.from_cbor_hex(applyDoubleCborEncoding(script)),
+        ),
         value: { type, script: applyDoubleCborEncoding(script) },
       };
     case "PlutusV3":
       return {
-        key: CML.PlutusV3Script.from_cbor_hex(applyDoubleCborEncoding(script))
-          .hash()
-          .to_hex(),
+        key: scriptHashHex(
+          CML.PlutusV3Script.from_cbor_hex(applyDoubleCborEncoding(script)),
+        ),
         value: { type, script: applyDoubleCborEncoding(script) },
       };
     default:

--- a/packages/lucid/src/tx-builder/internal/Collect.ts
+++ b/packages/lucid/src/tx-builder/internal/Collect.ts
@@ -1,6 +1,8 @@
 import { Effect, pipe } from "effect";
 import { Data } from "@lucid-evolution/plutus";
 import { utxoToCore } from "@lucid-evolution/utils";
+import { withCMLScope } from "@lucid-evolution/core-utils";
+import type { TxBuilderConfig } from "../TxBuilder.js";
 import { Redeemer, RedeemerBuilder, UTxO } from "@lucid-evolution/core-types";
 import { ERROR_MESSAGE, TxBuilderError } from "../../Errors.js";
 import * as CML from "@anastasia-labs/cardano-multiplatform-lib-nodejs";
@@ -30,97 +32,110 @@ export const collectFromUTxO =
         // Store inputs for later use in the txBuilder
         if (collectInputs) config.collectedInputs.push(utxo);
         //TODO: Add config.collectedAssets
-        const input = CML.SingleInputBuilder.from_transaction_unspent_output(
-          utxoToCore({ ...utxo, datum: resolvedDatum }),
+        const input = withCMLScope((own) =>
+          CML.SingleInputBuilder.from_transaction_unspent_output(
+            own(utxoToCore({ ...utxo, datum: resolvedDatum })),
+          ),
         );
-        const credential = paymentCredentialOf(utxo.address);
+        yield* addCollectedInput(config, input, utxo, redeemer).pipe(
+          Effect.ensuring(Effect.sync(() => input.free())),
+        );
+      }
+    });
 
-        if (credential.type == "Script") {
-          const script = yield* pipe(
-            Effect.fromNullable(config.scripts.get(credential.hash)),
-            Effect.orElseFail(() =>
-              collectError(
-                collectError(ERROR_MESSAGE.MISSING_SCRIPT(credential.hash)),
+const missingRedeemer = (redeemer?: Redeemer) =>
+  pipe(
+    Effect.fromNullable(redeemer),
+    Effect.orElseFail(() => collectError(ERROR_MESSAGE.MISSING_REDEEMER)),
+  );
+
+const addPlutusInput = (
+  config: TxBuilderConfig,
+  input: CML.SingleInputBuilder,
+  utxo: UTxO,
+  script: CML.PlutusScript,
+  redeemer: Redeemer,
+): void =>
+  withCMLScope((own) => {
+    own(script);
+    const partial = own(toPartial(script, redeemer));
+    const requiredSigners = own(CML.Ed25519KeyHashList.new());
+    config.txBuilder.add_input(
+      own(
+        utxo.datum && utxo.datumHash
+          ? input.plutus_script(
+              partial,
+              requiredSigners,
+              own(CML.PlutusData.from_cbor_hex(utxo.datum)),
+            )
+          : input.plutus_script_inline_datum(partial, requiredSigners),
+      ),
+    );
+  });
+
+const addCollectedInput = (
+  config: TxBuilderConfig,
+  input: CML.SingleInputBuilder,
+  utxo: UTxO,
+  redeemer?: Redeemer,
+): Effect.Effect<void, TxBuilderError> =>
+  Effect.gen(function* () {
+    const credential = paymentCredentialOf(utxo.address);
+    if (credential.type != "Script") {
+      withCMLScope((own) =>
+        config.txBuilder.add_input(own(input.payment_key())),
+      );
+      return;
+    }
+    const script = yield* pipe(
+      Effect.fromNullable(config.scripts.get(credential.hash)),
+      Effect.orElseFail(() =>
+        collectError(
+          collectError(ERROR_MESSAGE.MISSING_SCRIPT(credential.hash)),
+        ),
+      ),
+    );
+    switch (script.type) {
+      case "Native":
+        withCMLScope((own) =>
+          config.txBuilder.add_input(
+            own(
+              input.native_script(
+                own(CML.NativeScript.from_cbor_hex(script.script)),
+                own(CML.NativeScriptWitnessInfo.assume_signature_count()),
+              ),
+            ),
+          ),
+        );
+        break;
+      case "PlutusV1": {
+        const red = yield* missingRedeemer(redeemer);
+        withCMLScope((own) => {
+          const partial = own(toPartial(own(toV1(script.script)), red));
+          config.txBuilder.add_input(
+            own(
+              input.plutus_script(
+                partial,
+                own(CML.Ed25519KeyHashList.new()),
+                own(CML.PlutusData.from_cbor_hex(utxo.datum!)),
               ),
             ),
           );
-          switch (script.type) {
-            case "Native":
-              config.txBuilder.add_input(
-                input.native_script(
-                  CML.NativeScript.from_cbor_hex(script.script),
-                  CML.NativeScriptWitnessInfo.assume_signature_count(),
-                ),
-              );
-              break;
-            case "PlutusV1": {
-              const red = yield* pipe(
-                Effect.fromNullable(redeemer),
-                Effect.orElseFail(() =>
-                  collectError(ERROR_MESSAGE.MISSING_REDEEMER),
-                ),
-              );
-              config.txBuilder.add_input(
-                input.plutus_script(
-                  toPartial(toV1(script.script), red),
-                  CML.Ed25519KeyHashList.new(),
-                  CML.PlutusData.from_cbor_hex(utxo.datum!),
-                ),
-              );
-              break;
-            }
-            case "PlutusV2": {
-              const v2 = toV2(script.script);
-              const red = yield* pipe(
-                Effect.fromNullable(redeemer),
-                Effect.orElseFail(() =>
-                  collectError(ERROR_MESSAGE.MISSING_REDEEMER),
-                ),
-              );
-              const partial = toPartial(v2, red);
-              config.txBuilder.add_input(
-                utxo.datum && utxo.datumHash
-                  ? input.plutus_script(
-                      partial,
-                      CML.Ed25519KeyHashList.new(),
-                      CML.PlutusData.from_cbor_hex(utxo.datum),
-                    )
-                  : input.plutus_script_inline_datum(
-                      partial,
-                      CML.Ed25519KeyHashList.new(),
-                    ),
-              );
-              break;
-            }
-            case "PlutusV3": {
-              const v3 = toV3(script.script);
-              const red = yield* pipe(
-                Effect.fromNullable(redeemer),
-                Effect.orElseFail(() =>
-                  collectError(ERROR_MESSAGE.MISSING_REDEEMER),
-                ),
-              );
-              const partial = toPartial(v3, red);
-              config.txBuilder.add_input(
-                utxo.datum && utxo.datumHash
-                  ? input.plutus_script(
-                      partial,
-                      CML.Ed25519KeyHashList.new(),
-                      CML.PlutusData.from_cbor_hex(utxo.datum),
-                    )
-                  : input.plutus_script_inline_datum(
-                      partial,
-                      CML.Ed25519KeyHashList.new(),
-                    ),
-              );
-              break;
-            }
-          }
-        } else {
-          config.txBuilder.add_input(input.payment_key());
-        }
+        });
+        break;
       }
-    });
+      case "PlutusV2": {
+        const red = yield* missingRedeemer(redeemer);
+        addPlutusInput(config, input, utxo, toV2(script.script), red);
+        break;
+      }
+      case "PlutusV3": {
+        const red = yield* missingRedeemer(redeemer);
+        addPlutusInput(config, input, utxo, toV3(script.script), red);
+        break;
+      }
+    }
+  });
 
 /* "collectFrom" for RedeemerBuilder needs similar utxo validations as done for Redeemer.
   These should happen before coin selection; so the effect this function returns is added

--- a/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
+++ b/packages/lucid/src/tx-builder/internal/CompleteTxBuilder.ts
@@ -29,6 +29,7 @@ import {
   TxBuilderError,
 } from "../../Errors.js";
 import { CML } from "../../core.js";
+import { freeCML, withCMLScope } from "@lucid-evolution/core-utils";
 import * as UPLC from "@lucid-evolution/uplc";
 import * as TxBuilder from "../TxBuilder.js";
 import * as TxSignBuilder from "../../tx-sign-builder/TxSignBuilder.js";
@@ -59,6 +60,7 @@ import {
   buildCanonicalRedeemerInfo,
   buildRedeemersFromCanonicalContext,
   canonicalRedeemerEntries,
+  freeCanonicalRedeemerEntries,
   CanonicalRedeemerInfo,
   cloneUTxOs,
   normalizeEvalUTxO,
@@ -72,6 +74,7 @@ import {
   transactionFixedPointFingerprint,
   voterForRedeemerIndex,
   witnessPurposeKey,
+  type BuilderRedeemerKey,
 } from "./RedeemerContext.js";
 
 const MAX_EVALUATION_ATTEMPTS = 8;
@@ -295,18 +298,22 @@ const completeCurrentConfig = (
         )) || evaluatedScriptBody;
     }
     yield* applyEffectiveFee(config, true, evaluatedScriptBody);
-    config.txBuilder.add_change_if_needed(
-      CML.Address.from_bech32(changeAddress),
-      true,
+    withCMLScope((own) =>
+      config.txBuilder.add_change_if_needed(
+        own(CML.Address.from_bech32(changeAddress)),
+        true,
+      ),
     );
     const builtTransaction = yield* Effect.try({
       try: () =>
-        config.txBuilder
-          .build(
-            CML.ChangeSelectionAlgo.Default,
-            CML.Address.from_bech32(changeAddress),
-          )
-          .build_unchecked(),
+        withCMLScope((own) =>
+          own(
+            config.txBuilder.build(
+              CML.ChangeSelectionAlgo.Default,
+              own(CML.Address.from_bech32(changeAddress)),
+            ),
+          ).build_unchecked(),
+        ),
       catch: (error) => completeTxError(error),
     });
     const shouldCanonicalize = canonical || internalOptions.forceCanonical;
@@ -324,10 +331,12 @@ const completeCurrentConfig = (
         ).transaction,
       catch: (error) => completeTxError(error),
     });
+    freeCML(builtTransaction, transactionBeforeScriptDataHash);
     const transaction = yield* refreshScriptDataHash(
       normalizedTransaction,
       config,
     );
+    if (transaction !== normalizedTransaction) normalizedTransaction.free();
 
     const derivedInputs = deriveInputsFromTransaction(transaction);
 
@@ -367,6 +376,9 @@ const completeStaticFromActions = (
       return yield* completeCurrentConfig(options);
     }),
     Effect.provide(Layer.succeed(TxConfig, { config: replayConfig })),
+    // The completed transaction is copied out of the builder; nothing keeps
+    // the replay's builder alive.
+    Effect.ensuring(Effect.sync(() => replayConfig.txBuilder.free())),
   );
 };
 
@@ -433,9 +445,13 @@ const completeDelayedFromActions = (
         Effect.provide(Layer.succeed(TxConfig, { config: replayConfig })),
         Effect.either,
       );
+      // Each attempt builds in its own TransactionBuilder; free it once the
+      // attempt's transaction has been copied out or the attempt is discarded.
+      const discardReplay = () => replayConfig.txBuilder.free();
 
       if (Either.isLeft(completion)) {
         if (!(completion.left instanceof RedeemerInputRefreshRequired)) {
+          discardReplay();
           return yield* Effect.fail(completion.left);
         }
 
@@ -447,6 +463,8 @@ const completeDelayedFromActions = (
         );
         currentRedeemers = nextRedeemers;
         redeemerInputFingerprint = canonicalInputFingerprint(tx);
+        tx.free();
+        discardReplay();
         previousFingerprint = undefined;
         bootstrapWalletInputs = [];
         continue;
@@ -474,6 +492,7 @@ const completeDelayedFromActions = (
         redeemerBuilderCache,
       );
       redeemerInputFingerprint = canonicalInputFingerprint(tx);
+      discardReplay();
 
       if (!redeemerMapsEqual(currentRedeemers, nextRedeemers)) {
         currentRedeemers = nextRedeemers;
@@ -506,23 +525,26 @@ const buildDelayedRedeemers = (
       tx,
       allResolvedInputs,
     );
+    // The redeemer builders run to completion inside this call, so the
+    // context's transaction body is not needed once it returns.
     const nextRedeemers = yield* buildRedeemersFromCanonicalContext(
       redeemerInfo,
       replayConfig.pendingRedeemers,
       redeemerBuilderCache,
-    );
+    ).pipe(Effect.ensuring(Effect.sync(() => redeemerInfo.txBody.free())));
     return nextRedeemers;
   });
 
-const canonicalInputFingerprint = (tx: CML.Transaction): string => {
-  const canonical = CML.Transaction.from_cbor_bytes(
-    tx.to_canonical_cbor_bytes(),
-  );
-  const inputs = canonical.body().inputs();
-  return Array.from({ length: inputs.len() }, (_, index) =>
-    inputs.get(index).to_canonical_cbor_hex(),
-  ).join(",");
-};
+const canonicalInputFingerprint = (tx: CML.Transaction): string =>
+  withCMLScope((own) => {
+    const canonical = own(
+      CML.Transaction.from_cbor_bytes(tx.to_canonical_cbor_bytes()),
+    );
+    const inputs = own(own(canonical.body()).inputs());
+    return Array.from({ length: inputs.len() }, (_, index) =>
+      own(inputs.get(index)).to_canonical_cbor_hex(),
+    ).join(",");
+  });
 
 const addWalletInputs = (
   config: TxBuilder.TxBuilderConfig,
@@ -534,10 +556,13 @@ const addWalletInputs = (
         if (config.collectedInputs.some((input) => isEqualUTxO(input, utxo))) {
           continue;
         }
-        const input = CML.SingleInputBuilder.from_transaction_unspent_output(
-          utxoToCore(utxo),
-        ).payment_key();
-        config.txBuilder.add_input(input);
+        withCMLScope((own) => {
+          const core = own(utxoToCore(utxo));
+          const builder = own(
+            CML.SingleInputBuilder.from_transaction_unspent_output(core),
+          );
+          config.txBuilder.add_input(own(builder.payment_key()));
+        });
         config.collectedInputs = [...config.collectedInputs, utxo];
       }
     },
@@ -555,9 +580,10 @@ const collectKnownRedeemerExUnits = (
       ...config.readInputs,
     ];
     const info = yield* buildCanonicalRedeemerInfo(tx, allResolvedInputs);
-    const entries = tx.witness_set().redeemers()
-      ? canonicalRedeemerEntries(tx.witness_set().redeemers()!)
-      : [];
+    const entries = withCMLScope((own) => {
+      const redeemers = own(own(tx.witness_set()).redeemers());
+      return redeemers ? canonicalRedeemerEntries(redeemers) : [];
+    });
     const known: KnownRedeemerExUnits = new Map();
     for (let index = 0; index < info.redeemers.length; index++) {
       const purpose = info.redeemers[index];
@@ -568,6 +594,8 @@ const collectKnownRedeemerExUnits = (
         steps: Number(entry.exUnits.steps()),
       });
     }
+    freeCanonicalRedeemerEntries(entries);
+    info.txBody.free();
     return known;
   });
 
@@ -775,14 +803,17 @@ export const decodeLegacyRedeemers = (
 ): EvalRedeemer[] => {
   const evalRedeemers: EvalRedeemer[] = [];
   for (const bytes of uplcEval) {
-    const redeemer = CML.LegacyRedeemer.from_cbor_bytes(bytes);
-    evalRedeemers.push({
-      ex_units: {
-        mem: Number(redeemer.ex_units().mem()),
-        steps: Number(redeemer.ex_units().steps()),
-      },
-      redeemer_index: Number(redeemer.index()),
-      redeemer_tag: fromCMLRedeemerTag(redeemer.tag()),
+    withCMLScope((own) => {
+      const redeemer = own(CML.LegacyRedeemer.from_cbor_bytes(bytes));
+      const exUnits = own(redeemer.ex_units());
+      evalRedeemers.push({
+        ex_units: {
+          mem: Number(exUnits.mem()),
+          steps: Number(exUnits.steps()),
+        },
+        redeemer_index: Number(redeemer.index()),
+        redeemer_tag: fromCMLRedeemerTag(redeemer.tag()),
+      });
     });
   }
   return evalRedeemers;
@@ -791,12 +822,20 @@ export const decodeLegacyRedeemers = (
 const evalRedeemerKey = (evalRedeemer: EvalRedeemer): string =>
   `${evalRedeemer.redeemer_tag}:${evalRedeemer.redeemer_index}`;
 
-export const expectedRedeemerKeySet = (redeemers: CML.Redeemers): Set<string> =>
-  new Set(
-    redeemerWitnessKeys(redeemers).map(
-      ({ tag, index }) => `${fromCMLRedeemerTag(tag)}:${index.toString()}`,
-    ),
-  );
+export const expectedRedeemerKeySet = (
+  redeemers: CML.Redeemers,
+): Set<string> => {
+  const keys = redeemerWitnessKeys(redeemers);
+  try {
+    return new Set(
+      keys.map(
+        ({ tag, index }) => `${fromCMLRedeemerTag(tag)}:${index.toString()}`,
+      ),
+    );
+  } finally {
+    for (const { key } of keys) key.free();
+  }
+};
 
 const validateEvalRedeemer = (
   evalRedeemer: EvalRedeemer,
@@ -836,10 +875,7 @@ export const applyEvaluationResult = (
   txbuilder: CML.TransactionBuilder,
   expectedKeys: Set<string>,
   evaluator?: string,
-  builderKeyByLedgerKey: ReadonlyMap<
-    string,
-    CML.RedeemerWitnessKey
-  > = new Map(),
+  builderKeyByLedgerKey: ReadonlyMap<string, BuilderRedeemerKey> = new Map(),
 ): void => {
   if (expectedKeys.size > 0 && evalRedeemerList.length === 0) {
     throw evaluatorError(
@@ -853,11 +889,18 @@ export const applyEvaluationResult = (
     key: CML.RedeemerWitnessKey;
     exUnits: CML.ExUnits;
   }> = [];
+  const release = () => {
+    for (const { key, exUnits } of updates) {
+      exUnits.free();
+      key.free();
+    }
+  };
 
   for (const evalRedeemer of evalRedeemerList) {
     validateEvalRedeemer(evalRedeemer, evaluator);
     const key = evalRedeemerKey(evalRedeemer);
     if (seen.has(key)) {
+      release();
       throw evaluatorError(
         `Evaluator returned duplicate result for redeemer ${key}`,
         evaluator,
@@ -865,6 +908,7 @@ export const applyEvaluationResult = (
     }
     seen.add(key);
     if (!expectedKeys.has(key)) {
+      release();
       throw evaluatorError(
         `Evaluator returned result for unexpected redeemer ${key}`,
         evaluator,
@@ -874,19 +918,21 @@ export const applyEvaluationResult = (
       BigInt(evalRedeemer.ex_units.mem),
       BigInt(evalRedeemer.ex_units.steps),
     );
+    const builderKey = builderKeyByLedgerKey.get(key);
     updates.push({
-      key:
-        builderKeyByLedgerKey.get(key) ??
-        CML.RedeemerWitnessKey.new(
-          toCMLRedeemerTag(evalRedeemer.redeemer_tag),
-          BigInt(evalRedeemer.redeemer_index),
-        ),
+      key: builderKey
+        ? CML.RedeemerWitnessKey.new(builderKey.tag, builderKey.index)
+        : CML.RedeemerWitnessKey.new(
+            toCMLRedeemerTag(evalRedeemer.redeemer_tag),
+            BigInt(evalRedeemer.redeemer_index),
+          ),
       exUnits,
     });
   }
 
   for (const expectedKey of expectedKeys) {
     if (!seen.has(expectedKey)) {
+      release();
       throw evaluatorError(
         `Evaluator did not return a result for redeemer ${expectedKey}`,
         evaluator,
@@ -897,41 +943,48 @@ export const applyEvaluationResult = (
   for (const { key, exUnits } of updates) {
     txbuilder.set_exunits(key, exUnits);
   }
+  release();
 };
 
-export const redeemerWitnessKeys = (redeemers: CML.Redeemers) => {
-  const keys: Array<{
-    key: CML.RedeemerWitnessKey;
-    tag: CML.RedeemerTag;
-    index: bigint;
-  }> = [];
-  const arrLegacyRedeemer = redeemers.as_arr_legacy_redeemer();
-  if (arrLegacyRedeemer) {
-    for (let i = 0; i < arrLegacyRedeemer.len(); i++) {
-      const redeemer = arrLegacyRedeemer.get(i);
-      keys.push({
-        key: CML.RedeemerWitnessKey.from_redeemer(redeemer),
-        tag: redeemer.tag(),
-        index: redeemer.index(),
-      });
+/**
+ * The returned `key` objects belong to the caller, which frees them once the
+ * builder has consumed them.
+ */
+export const redeemerWitnessKeys = (redeemers: CML.Redeemers) =>
+  withCMLScope((own) => {
+    const keys: Array<{
+      key: CML.RedeemerWitnessKey;
+      tag: CML.RedeemerTag;
+      index: bigint;
+    }> = [];
+    const arrLegacyRedeemer = own(redeemers.as_arr_legacy_redeemer());
+    if (arrLegacyRedeemer) {
+      for (let i = 0; i < arrLegacyRedeemer.len(); i++) {
+        const redeemer = own(arrLegacyRedeemer.get(i));
+        keys.push({
+          key: CML.RedeemerWitnessKey.from_redeemer(redeemer),
+          tag: redeemer.tag(),
+          index: redeemer.index(),
+        });
+      }
     }
-  }
 
-  const mapRedeemerKeyToRedeemerVal =
-    redeemers.as_map_redeemer_key_to_redeemer_val();
-  if (mapRedeemerKeyToRedeemerVal) {
-    const mapKeys = mapRedeemerKeyToRedeemerVal.keys();
-    for (let i = 0; i < mapKeys.len(); i++) {
-      const key = mapKeys.get(i);
-      keys.push({
-        key: CML.RedeemerWitnessKey.new(key.tag(), key.index()),
-        tag: key.tag(),
-        index: key.index(),
-      });
+    const mapRedeemerKeyToRedeemerVal = own(
+      redeemers.as_map_redeemer_key_to_redeemer_val(),
+    );
+    if (mapRedeemerKeyToRedeemerVal) {
+      const mapKeys = own(mapRedeemerKeyToRedeemerVal.keys());
+      for (let i = 0; i < mapKeys.len(); i++) {
+        const key = own(mapKeys.get(i));
+        keys.push({
+          key: CML.RedeemerWitnessKey.new(key.tag(), key.index()),
+          tag: key.tag(),
+          index: key.index(),
+        });
+      }
     }
-  }
-  return keys;
-};
+    return keys;
+  });
 
 export const applyBootstrapRedeemerExUnits = (
   redeemers: CML.Redeemers,
@@ -945,9 +998,14 @@ export const applyBootstrapRedeemerExUnits = (
     maxTxExMem,
     maxTxExSteps,
   );
-  for (const [index, { key }] of keys.entries()) {
-    const exUnits = budgets[index];
-    txbuilder.set_exunits(key, CML.ExUnits.new(exUnits.mem(), exUnits.steps()));
+  try {
+    for (const [index, { key }] of keys.entries()) {
+      const exUnits = budgets[index];
+      txbuilder.set_exunits(key, exUnits);
+    }
+  } finally {
+    for (const { key } of keys) key.free();
+    freeCML(...budgets);
   }
 };
 
@@ -1052,22 +1110,29 @@ const scriptHashForPurpose = (
       return purpose.policyId;
     case "withdraw":
       return getAddressDetails(purpose.rewardAddress).stakeCredential?.hash;
-    case "publish": {
-      const certificate = info.txBody.certs()?.get(Number(purpose.index));
-      return certificate ? scriptHashFromCertificate(certificate) : undefined;
-    }
-    case "vote": {
-      const voter =
-        voterByKey(info.txBody, purpose.voterKey) ??
-        voterForRedeemerIndex(tx, purpose.index);
-      return voter?.script_hash()?.to_hex();
-    }
-    case "propose": {
-      const proposal =
-        proposalByKey(info.txBody, purpose.proposalKey) ??
-        proposalProcedureForRedeemerIndex(tx, purpose.index);
-      return proposal?.gov_action().script_hash()?.to_hex();
-    }
+    case "publish":
+      return withCMLScope((own) => {
+        const certificate = own(
+          own(info.txBody.certs())?.get(Number(purpose.index)),
+        );
+        return certificate ? scriptHashFromCertificate(certificate) : undefined;
+      });
+    case "vote":
+      return withCMLScope((own) => {
+        const voter = own(
+          voterByKey(info.txBody, purpose.voterKey) ??
+            voterForRedeemerIndex(tx, purpose.index),
+        );
+        return own(voter?.script_hash())?.to_hex();
+      });
+    case "propose":
+      return withCMLScope((own) => {
+        const proposal = own(
+          proposalByKey(info.txBody, purpose.proposalKey) ??
+            proposalProcedureForRedeemerIndex(tx, purpose.index),
+        );
+        return own(own(proposal?.gov_action())?.script_hash())?.to_hex();
+      });
   }
 };
 
@@ -1076,12 +1141,14 @@ const usedPlutusLanguages = (
   config: TxBuilder.TxBuilderConfig,
 ): Effect.Effect<CML.LanguageList, TxBuilderError> =>
   Effect.gen(function* () {
-    const witnessLanguages = tx.witness_set().languages();
-    const languages = new Set<CML.Language>();
-
-    for (let i = 0; i < witnessLanguages.len(); i++) {
-      languages.add(witnessLanguages.get(i));
-    }
+    const languages = withCMLScope((own) => {
+      const witnessLanguages = own(own(tx.witness_set()).languages());
+      const found = new Set<CML.Language>();
+      for (let i = 0; i < witnessLanguages.len(); i++) {
+        found.add(witnessLanguages.get(i));
+      }
+      return found;
+    });
 
     const resolvedInputs = [
       ...config.walletInputs,
@@ -1093,6 +1160,7 @@ const usedPlutusLanguages = (
     for (const purpose of redeemerInfo.redeemers) {
       const scriptHash = scriptHashForPurpose(purpose, tx, redeemerInfo);
       if (!scriptHash) {
+        redeemerInfo.txBody.free();
         yield* completeTxError(
           `Unable to resolve script hash for ${purpose.tag}:${purpose.index} redeemer`,
         );
@@ -1100,6 +1168,7 @@ const usedPlutusLanguages = (
       }
       const script = config.scripts.get(scriptHash);
       if (!script) {
+        redeemerInfo.txBody.free();
         yield* completeTxError(
           `Unable to resolve script for ${purpose.tag} redeemer ${scriptHash}`,
         );
@@ -1108,6 +1177,7 @@ const usedPlutusLanguages = (
       const language = scriptTypeToLanguage(script.type);
       if (language !== undefined) languages.add(language);
     }
+    redeemerInfo.txBody.free();
 
     const result = CML.LanguageList.new();
     [...languages]
@@ -1121,91 +1191,123 @@ const refreshScriptDataHash = (
   config: TxBuilder.TxBuilderConfig,
 ): Effect.Effect<CML.Transaction, TxBuilderError> =>
   Effect.gen(function* () {
-    const redeemers = tx.witness_set().redeemers();
-    if (!redeemers) return tx;
+    const witnessSet = tx.witness_set();
+    const redeemers = witnessSet.redeemers();
+    if (!redeemers) {
+      witnessSet.free();
+      return tx;
+    }
 
-    const datums = tx.witness_set().plutus_datums() ?? CML.PlutusDataList.new();
-    const usedLangs = yield* usedPlutusLanguages(tx, config);
+    const datums = witnessSet.plutus_datums() ?? CML.PlutusDataList.new();
+    const usedLangs = yield* usedPlutusLanguages(tx, config).pipe(
+      Effect.tapError(() =>
+        Effect.sync(() => freeCML(witnessSet, redeemers, datums)),
+      ),
+    );
     const scriptDataHash = yield* Effect.try({
-      try: () =>
-        CML.calc_script_data_hash(
-          redeemers,
-          datums,
-          config.lucidConfig.costModels,
-          usedLangs,
-        ),
-      catch: (error) => completeTxError(error),
+      try: () => {
+        try {
+          return CML.calc_script_data_hash(
+            redeemers,
+            datums,
+            config.lucidConfig.costModels,
+            usedLangs,
+          );
+        } finally {
+          freeCML(redeemers, datums, usedLangs);
+        }
+      },
+      catch: (error) => {
+        witnessSet.free();
+        return completeTxError(error);
+      },
     });
     const resolvedScriptDataHash = yield* pipe(
       Effect.fromNullable(scriptDataHash),
-      Effect.orElseFail(() =>
-        completeTxError("Unable to calculate script data hash"),
-      ),
+      Effect.orElseFail(() => {
+        witnessSet.free();
+        return completeTxError("Unable to calculate script data hash");
+      }),
     );
-    const body = tx.body();
-    body.set_script_data_hash(resolvedScriptDataHash);
-    return CML.Transaction.new(
-      body,
-      tx.witness_set(),
-      tx.is_valid(),
-      tx.auxiliary_data(),
-    );
+    return withCMLScope((own) => {
+      own(witnessSet);
+      const body = own(tx.body());
+      body.set_script_data_hash(own(resolvedScriptDataHash));
+      // `Transaction.new` takes ownership of the auxiliary data.
+      return CML.Transaction.new(
+        body,
+        witnessSet,
+        tx.is_valid(),
+        tx.auxiliary_data(),
+      );
+    });
   });
 
-export const setRedeemerstoZero = (tx: CML.Transaction): CML.Transaction => {
-  const redeemers = tx.witness_set().redeemers();
-  if (!redeemers) return tx;
-  const arrLegacyRedeemer = redeemers.as_arr_legacy_redeemer();
-  if (arrLegacyRedeemer) {
-    const redeemerList = CML.LegacyRedeemerList.new();
-    for (let i = 0; i < arrLegacyRedeemer.len(); i++) {
-      const redeemer = arrLegacyRedeemer.get(i);
-      const dummyRedeemer = CML.LegacyRedeemer.new(
-        redeemer.tag(),
-        redeemer.index(),
-        redeemer.data(),
-        CML.ExUnits.new(0n, 0n),
+/**
+ * Returns `tx` itself when it carries no redeemers, otherwise a new
+ * transaction the caller owns.
+ */
+export const setRedeemerstoZero = (tx: CML.Transaction): CML.Transaction =>
+  withCMLScope((own) => {
+    const witnessSet = own(tx.witness_set());
+    const redeemers = own(witnessSet.redeemers());
+    if (!redeemers) return tx;
+    const zeroExUnits = () => own(CML.ExUnits.new(0n, 0n));
+    const arrLegacyRedeemer = own(redeemers.as_arr_legacy_redeemer());
+    if (arrLegacyRedeemer) {
+      const redeemerList = own(CML.LegacyRedeemerList.new());
+      for (let i = 0; i < arrLegacyRedeemer.len(); i++) {
+        const redeemer = own(arrLegacyRedeemer.get(i));
+        const dummyRedeemer = own(
+          CML.LegacyRedeemer.new(
+            redeemer.tag(),
+            redeemer.index(),
+            own(redeemer.data()),
+            zeroExUnits(),
+          ),
+        );
+        redeemerList.add(dummyRedeemer);
+      }
+      witnessSet.set_redeemers(
+        own(CML.Redeemers.new_arr_legacy_redeemer(redeemerList)),
       );
-      redeemerList.add(dummyRedeemer);
-    }
-
-    const dummyWitnessSet = tx.witness_set();
-    dummyWitnessSet.set_redeemers(
-      CML.Redeemers.new_arr_legacy_redeemer(redeemerList),
-    );
-    return CML.Transaction.new(
-      tx.body(),
-      dummyWitnessSet,
-      true,
-      tx.auxiliary_data(),
-    );
-  }
-  const mapRedeemerKeyToRedeemerVal =
-    redeemers.as_map_redeemer_key_to_redeemer_val();
-  if (mapRedeemerKeyToRedeemerVal) {
-    const dummyRedeemerMap = CML.MapRedeemerKeyToRedeemerVal.new();
-    const keys = mapRedeemerKeyToRedeemerVal.keys();
-    for (let i = 0; i < keys.len(); i++) {
-      const key = keys.get(i);
-      const value = mapRedeemerKeyToRedeemerVal.get(key)!;
-      dummyRedeemerMap.insert(
-        key,
-        CML.RedeemerVal.new(value.data(), CML.ExUnits.new(0n, 0n)),
+      // `Transaction.new` takes ownership of the auxiliary data.
+      return CML.Transaction.new(
+        own(tx.body()),
+        witnessSet,
+        true,
+        tx.auxiliary_data(),
       );
     }
-    const dummyWitnessSet = tx.witness_set();
-    dummyWitnessSet.set_redeemers(
-      CML.Redeemers.new_map_redeemer_key_to_redeemer_val(dummyRedeemerMap),
+    const mapRedeemerKeyToRedeemerVal = own(
+      redeemers.as_map_redeemer_key_to_redeemer_val(),
     );
-    return CML.Transaction.new(
-      tx.body(),
-      dummyWitnessSet,
-      true,
-      tx.auxiliary_data(),
-    );
-  }
-  return tx;
-};
+    if (mapRedeemerKeyToRedeemerVal) {
+      const dummyRedeemerMap = own(CML.MapRedeemerKeyToRedeemerVal.new());
+      const keys = own(mapRedeemerKeyToRedeemerVal.keys());
+      for (let i = 0; i < keys.len(); i++) {
+        const key = own(keys.get(i));
+        const value = own(mapRedeemerKeyToRedeemerVal.get(key)!);
+        dummyRedeemerMap.insert(
+          key,
+          own(CML.RedeemerVal.new(own(value.data()), zeroExUnits())),
+        );
+      }
+      witnessSet.set_redeemers(
+        own(
+          CML.Redeemers.new_map_redeemer_key_to_redeemer_val(dummyRedeemerMap),
+        ),
+      );
+      // `Transaction.new` takes ownership of the auxiliary data.
+      return CML.Transaction.new(
+        own(tx.body()),
+        witnessSet,
+        true,
+        tx.auxiliary_data(),
+      );
+    }
+    return tx;
+  });
 
 const applyCollateral = (
   setCollateral: bigint,
@@ -1215,28 +1317,34 @@ const applyCollateral = (
   Effect.gen(function* () {
     const { config } = yield* TxConfig;
     for (const utxo of collateralInputs) {
-      const collateralInput =
-        CML.SingleInputBuilder.from_transaction_unspent_output(
-          utxoToCore(utxo),
-        ).payment_key();
-      config.txBuilder.add_collateral(collateralInput);
+      withCMLScope((own) => {
+        const core = own(utxoToCore(utxo));
+        const builder = own(
+          CML.SingleInputBuilder.from_transaction_unspent_output(core),
+        );
+        config.txBuilder.add_collateral(own(builder.payment_key()));
+      });
     }
     const returnassets = pipe(
       sumAssetsFromInputs(collateralInputs),
       Record.union({ lovelace: -setCollateral }, _BigInt.sum),
     );
 
-    const collateralOutputBuilder =
-      CML.TransactionOutputBuilder.new().with_address(
-        CML.Address.from_bech32(changeAddress),
+    withCMLScope((own) => {
+      const collateralOutputBuilder = own(
+        own(CML.TransactionOutputBuilder.new()).with_address(
+          own(CML.Address.from_bech32(changeAddress)),
+        ),
       );
-    config.txBuilder.set_collateral_return(
-      collateralOutputBuilder
-        .next()
-        .with_value(assetsToValue(returnassets))
-        .build()
-        .output(),
-    );
+      const result = own(
+        own(
+          own(collateralOutputBuilder.next()).with_value(
+            own(assetsToValue(returnassets)),
+          ),
+        ).build(),
+      );
+      config.txBuilder.set_collateral_return(own(result.output()));
+    });
   });
 
 const findCollateral = (
@@ -1355,9 +1463,14 @@ const buildEvaluationDraft = (
 ): Effect.Effect<CML.Transaction, TxBuilderError> =>
   Effect.try({
     try: () =>
-      config.txBuilder
-        .build_for_evaluation(0, CML.Address.from_bech32(changeAddress))
-        .draft_tx(),
+      withCMLScope((own) =>
+        own(
+          config.txBuilder.build_for_evaluation(
+            0,
+            own(CML.Address.from_bech32(changeAddress)),
+          ),
+        ).draft_tx(),
+      ),
     catch: (error) => completeTxError(error),
   });
 
@@ -1370,9 +1483,13 @@ const buildEvaluationCandidate = (
   Effect.gen(function* () {
     yield* applyEffectiveFee(config, script_calculation, forceExplicitFee);
     const candidate = yield* buildEvaluationDraft(config, changeAddress);
-    if (forceExplicitFee || !candidate.witness_set().redeemers()) {
+    const hasRedeemers = withCMLScope(
+      (own) => own(own(candidate.witness_set()).redeemers()) !== undefined,
+    );
+    if (forceExplicitFee || !hasRedeemers) {
       return candidate;
     }
+    candidate.free();
     yield* applyEffectiveFee(config, script_calculation, true);
     return yield* buildEvaluationDraft(config, changeAddress);
   });
@@ -1394,7 +1511,10 @@ const prepareRedeemerContextCandidate = (
         ).transaction,
       catch: (error) => completeTxError(error),
     });
-    return yield* refreshScriptDataHash(normalized, config);
+    canonical.free();
+    const refreshed = yield* refreshScriptDataHash(normalized, config);
+    if (refreshed !== normalized) normalized.free();
+    return refreshed;
   });
 
 const applyKnownRedeemerExUnits = (
@@ -1418,8 +1538,16 @@ const applyKnownRedeemerExUnits = (
         ),
       catch: (error) => completeTxError(error),
     });
-    const redeemers = normalization.transaction.witness_set().redeemers();
-    if (!redeemers) return false;
+    candidate.free();
+    const transaction = normalization.transaction;
+    const expectedKeys = withCMLScope((own) => {
+      const redeemers = own(own(transaction.witness_set()).redeemers());
+      return redeemers ? expectedRedeemerKeySet(redeemers) : undefined;
+    });
+    if (!expectedKeys) {
+      transaction.free();
+      return false;
+    }
 
     const resolvedInputs = [
       ...config.walletInputs,
@@ -1427,9 +1555,10 @@ const applyKnownRedeemerExUnits = (
       ...config.readInputs,
     ];
     const info = yield* buildCanonicalRedeemerInfo(
-      normalization.transaction,
+      transaction,
       resolvedInputs,
-    );
+    ).pipe(Effect.ensuring(Effect.sync(() => transaction.free())));
+    info.txBody.free();
     const evalRedeemers: EvalRedeemer[] = [];
     for (const purpose of info.redeemers) {
       const exUnits = known.get(
@@ -1448,7 +1577,7 @@ const applyKnownRedeemerExUnits = (
         applyEvaluationResult(
           evalRedeemers,
           config.txBuilder,
-          expectedRedeemerKeySet(redeemers),
+          expectedKeys,
           "delayed-redeemer fixed point",
           normalization.builderKeyByLedgerKey,
         ),
@@ -1457,8 +1586,14 @@ const applyKnownRedeemerExUnits = (
     return true;
   });
 
-const evaluationFixedPointFingerprint = (tx: CML.Transaction): string =>
-  transactionFixedPointFingerprint(setRedeemerstoZero(tx));
+const evaluationFixedPointFingerprint = (tx: CML.Transaction): string => {
+  const zeroed = setRedeemerstoZero(tx);
+  try {
+    return transactionFixedPointFingerprint(zeroed);
+  } finally {
+    if (zeroed !== tx) zeroed.free();
+  }
+};
 
 const evaluateUntilStable = (
   config: TxBuilder.TxBuilderConfig,
@@ -1484,8 +1619,13 @@ const evaluateUntilStable = (
         script_calculation,
         forceExplicitFee,
       );
-      const redeemers = candidate.witness_set().redeemers();
-      if (!redeemers) return false;
+      const redeemers = withCMLScope((own) =>
+        own(candidate.witness_set()).redeemers(),
+      );
+      if (!redeemers) {
+        candidate.free();
+        return false;
+      }
       forceExplicitFee = true;
 
       if (bootstrapExUnits) {
@@ -1497,8 +1637,10 @@ const evaluateUntilStable = (
           config.lucidConfig.protocolParameters.maxTxExMem,
           config.lucidConfig.protocolParameters.maxTxExSteps,
         );
+        freeCML(redeemers, candidate);
         return true;
       }
+      redeemers.free();
 
       if (
         redeemerInputFingerprint !== undefined &&
@@ -1507,7 +1649,7 @@ const evaluateUntilStable = (
         const contextCandidate = yield* prepareRedeemerContextCandidate(
           candidate,
           config,
-        );
+        ).pipe(Effect.ensuring(Effect.sync(() => candidate.free())));
         return yield* Effect.fail(
           new RedeemerInputRefreshRequired(contextCandidate),
         );
@@ -1516,7 +1658,10 @@ const evaluateUntilStable = (
       // Re-evaluate only when the zero-exunit candidate changes in a way that
       // scripts can observe, such as fee or change-output drift after ex-units.
       const fingerprint = evaluationFixedPointFingerprint(candidate);
-      if (fingerprint === previousFingerprint) return true;
+      if (fingerprint === previousFingerprint) {
+        candidate.free();
+        return true;
+      }
       previousFingerprint = fingerprint;
 
       yield* evaluateTransaction(
@@ -1525,7 +1670,7 @@ const evaluateUntilStable = (
         walletInputs,
         localUPLCEval,
         evaluator,
-      );
+      ).pipe(Effect.ensuring(Effect.sync(() => candidate.free())));
     }
 
     return yield* completeTxError(
@@ -1561,12 +1706,19 @@ const makeProviderEvaluator = (provider: Provider): EvaluatorAdapter => ({
 const makeDefaultAikenEvaluator = (): EvaluatorAdapter => ({
   name: "aiken",
   evaluate: async ({ tx, additionalUTxOs, context }) => {
-    const ins = additionalUTxOs.map((utxo) => utxoToTransactionInput(utxo));
-    const outs = additionalUTxOs.map((utxo) => utxoToTransactionOutput(utxo));
+    const { txBytes, inputBytes, outputBytes } = withCMLScope((own) => ({
+      txBytes: own(CML.Transaction.from_cbor_hex(tx)).to_cbor_bytes(),
+      inputBytes: additionalUTxOs.map((utxo) =>
+        own(utxoToTransactionInput(utxo)).to_cbor_bytes(),
+      ),
+      outputBytes: additionalUTxOs.map((utxo) =>
+        own(utxoToTransactionOutput(utxo)).to_cbor_bytes(),
+      ),
+    }));
     const uplcEval = UPLC.eval_phase_two_raw(
-      CML.Transaction.from_cbor_hex(tx).to_cbor_bytes(),
-      ins.map((value) => value.to_cbor_bytes()),
-      outs.map((value) => value.to_cbor_bytes()),
+      txBytes,
+      inputBytes,
+      outputBytes,
       context.costModels.to_cbor_bytes(),
       context.protocolParameters.maxTxExSteps,
       context.protocolParameters.maxTxExMem,
@@ -1637,22 +1789,32 @@ const evaluateTransaction = (
         ),
       catch: (error) => wrapEvaluatorCause(error, name),
     });
-    const txEvaluation = yield* refreshScriptDataHash(
-      setRedeemerstoZero(normalization.transaction),
-      config,
+    const normalized = normalization.transaction;
+    const zeroed = setRedeemerstoZero(normalized);
+    const txEvaluation = yield* refreshScriptDataHash(zeroed, config).pipe(
+      Effect.tapError(() => Effect.sync(() => freeCML(normalized, zeroed))),
     );
-    const redeemers = txEvaluation.witness_set().redeemers();
-    if (!redeemers) return;
-    const expectedKeys = expectedRedeemerKeySet(redeemers);
+    // Any of the three may be the same object; freeCML frees each one once.
+    const release = () => freeCML(normalized, zeroed, txEvaluation);
+    const expectedKeys = withCMLScope((own) => {
+      const redeemers = own(own(txEvaluation.witness_set()).redeemers());
+      return redeemers ? expectedRedeemerKeySet(redeemers) : undefined;
+    });
+    if (!expectedKeys) {
+      release();
+      return;
+    }
     const txUtxos = yield* resolveEvaluationUTxOs(
       txEvaluation,
       walletInputs,
       config,
-    );
+    ).pipe(Effect.tapError(() => Effect.sync(release)));
+    const txHex = txEvaluation.to_cbor_hex();
+    release();
     const evalRedeemers = yield* Effect.tryPromise({
       try: () =>
         adapter.evaluate({
-          tx: txEvaluation.to_cbor_hex(),
+          tx: txHex,
           additionalUTxOs: txUtxos,
           context: makeEvaluationContext(config),
         }),
@@ -1679,38 +1841,45 @@ const calculateMinLovelace = (
 ): bigint => {
   const dummyAddress =
     "addr_test1qrngfyc452vy4twdrepdjc50d4kvqutgt0hs9w6j2qhcdjfx0gpv7rsrjtxv97rplyz3ymyaqdwqa635zrcdena94ljs0xy950";
-  return CML.TransactionOutputBuilder.new()
-    .with_address(
+  return withCMLScope((own) => {
+    const address = own(
       CML.Address.from_bech32(changeAddress ? changeAddress : dummyAddress),
-    )
-    .next()
-    .with_asset_and_min_required_coin(
-      multiAssets
-        ? assetsToValue(multiAssets).multi_asset()
-        : CML.MultiAsset.new(),
-      coinsPerUtxoByte,
-    )
-    .build()
-    .output()
-    .amount()
-    .coin();
+    );
+    const multiAsset = multiAssets
+      ? own(own(assetsToValue(multiAssets)).multi_asset())
+      : own(CML.MultiAsset.new());
+    const amountBuilder = own(
+      own(own(CML.TransactionOutputBuilder.new()).with_address(address)).next(),
+    );
+    const result = own(
+      own(
+        amountBuilder.with_asset_and_min_required_coin(
+          multiAsset,
+          coinsPerUtxoByte,
+        ),
+      ).build(),
+    );
+    return own(own(result.output()).amount()).coin();
+  });
 };
 
-const deriveInputsFromTransaction = (tx: CML.Transaction): UTxO[] => {
-  const outputs = tx.body().outputs();
-  const txHash = CML.hash_transaction(tx.body()).to_hex();
-  const utxos: UTxO[] = [];
-  for (let index = 0; index < outputs.len(); index++) {
-    const output = outputs.get(index);
-    const utxo: UTxO = {
-      txHash: txHash,
-      outputIndex: index,
-      ...coreToTxOutput(output),
-    };
-    utxos.push(utxo);
-  }
-  return utxos;
-};
+const deriveInputsFromTransaction = (tx: CML.Transaction): UTxO[] =>
+  withCMLScope((own) => {
+    const body = own(tx.body());
+    const outputs = own(body.outputs());
+    const txHash = own(CML.hash_transaction(body)).to_hex();
+    const utxos: UTxO[] = [];
+    for (let index = 0; index < outputs.len(); index++) {
+      const output = own(outputs.get(index));
+      const utxo: UTxO = {
+        txHash: txHash,
+        outputIndex: index,
+        ...coreToTxOutput(output),
+      };
+      utxos.push(utxo);
+    }
+    return utxos;
+  });
 
 /**
  * Returns a new `Assets`

--- a/packages/lucid/src/tx-builder/internal/Mint.ts
+++ b/packages/lucid/src/tx-builder/internal/Mint.ts
@@ -1,5 +1,5 @@
 import { Effect, pipe } from "effect";
-import { fromHex } from "@lucid-evolution/core-utils";
+import { withCMLScope } from "@lucid-evolution/core-utils";
 import { Assets, Redeemer } from "@lucid-evolution/core-types";
 import * as CML from "@anastasia-labs/cardano-multiplatform-lib-nodejs";
 import { toPartial, toV1, toV2, toV3 } from "./TxUtils.js";
@@ -21,68 +21,57 @@ export const mintAssets = (assets: Assets) => (redeemer?: Redeemer) =>
     const { config } = yield* TxConfig;
     const units = Object.keys(assets);
     const policyId = units[0].slice(0, 56);
-    const mintAssets = CML.MapAssetNameToNonZeroInt64.new();
     for (const unit of units) {
       if (unit.slice(0, 56) !== policyId) {
         yield* mintError(ERROR_MESSAGE.MULTIPLE_POLICIES);
       }
-      mintAssets.insert(CML.AssetName.from_hex(unit.slice(56)), assets[unit]);
     }
-    const mintBuilder = CML.SingleMintBuilder.new(mintAssets);
     const policy = yield* pipe(
       Effect.fromNullable(config.scripts.get(policyId)),
       Effect.orElseFail(() =>
         mintError(ERROR_MESSAGE.MISSING_POLICY(policyId)),
       ),
     );
-    switch (policy.type) {
-      case "Native":
-        config.txBuilder.add_mint(
-          mintBuilder.native_script(
-            CML.NativeScript.from_cbor_hex(policy.script),
-            CML.NativeScriptWitnessInfo.assume_signature_count(),
-          ),
+    const red =
+      policy.type === "Native"
+        ? undefined
+        : yield* pipe(
+            Effect.fromNullable(redeemer),
+            Effect.orElseFail(() => mintError(ERROR_MESSAGE.MISSING_REDEEMER)),
+          );
+    withCMLScope((own) => {
+      const mintAssets = own(CML.MapAssetNameToNonZeroInt64.new());
+      for (const unit of units) {
+        mintAssets.insert(
+          own(CML.AssetName.from_hex(unit.slice(56))),
+          assets[unit],
         );
-        break;
-
-      case "PlutusV1": {
-        const red = yield* pipe(
-          Effect.fromNullable(redeemer),
-          Effect.orElseFail(() => mintError(ERROR_MESSAGE.MISSING_REDEEMER)),
-        );
-        config.txBuilder.add_mint(
-          mintBuilder.plutus_script(
-            toPartial(toV1(policy.script), red),
-            CML.Ed25519KeyHashList.new(),
-          ),
-        );
-        break;
       }
-      case "PlutusV2": {
-        const red = yield* pipe(
-          Effect.fromNullable(redeemer),
-          Effect.orElseFail(() => mintError(ERROR_MESSAGE.MISSING_REDEEMER)),
-        );
-        config.txBuilder.add_mint(
-          mintBuilder.plutus_script(
-            toPartial(toV2(policy.script), red),
-            CML.Ed25519KeyHashList.new(),
-          ),
-        );
-        break;
-      }
-      case "PlutusV3": {
-        const red = yield* pipe(
-          Effect.fromNullable(redeemer),
-          Effect.orElseFail(() => mintError(ERROR_MESSAGE.MISSING_REDEEMER)),
-        );
-        config.txBuilder.add_mint(
-          mintBuilder.plutus_script(
-            toPartial(toV3(policy.script), red),
-            CML.Ed25519KeyHashList.new(),
-          ),
-        );
-        break;
-      }
-    }
+      // `native_script` and `plutus_script` consume the mint builder itself;
+      // their arguments and the result are ours to free.
+      const mintBuilder = CML.SingleMintBuilder.new(mintAssets);
+      const result = own(
+        policy.type === "Native"
+          ? mintBuilder.native_script(
+              own(CML.NativeScript.from_cbor_hex(policy.script)),
+              own(CML.NativeScriptWitnessInfo.assume_signature_count()),
+            )
+          : mintBuilder.plutus_script(
+              own(
+                toPartial(
+                  own(
+                    policy.type === "PlutusV1"
+                      ? toV1(policy.script)
+                      : policy.type === "PlutusV2"
+                        ? toV2(policy.script)
+                        : toV3(policy.script),
+                  ),
+                  red!,
+                ),
+              ),
+              own(CML.Ed25519KeyHashList.new()),
+            ),
+      );
+      config.txBuilder.add_mint(result);
+    });
   });

--- a/packages/lucid/src/tx-builder/internal/Pay.ts
+++ b/packages/lucid/src/tx-builder/internal/Pay.ts
@@ -10,6 +10,7 @@ import { Address, Assets, Script } from "@lucid-evolution/core-types";
 import { OutputDatum } from "../types.js";
 import * as TxBuilder from "../TxBuilder.js";
 import { CML } from "../../core.js";
+import { withCMLScope } from "@lucid-evolution/core-utils";
 import { toCMLAddress } from "./TxUtils.js";
 import { ERROR_MESSAGE, TxBuilderError } from "../../Errors.js";
 import { TxConfig } from "./Service.js";
@@ -25,37 +26,53 @@ export const payToAddress = (
 ) =>
   Effect.gen(function* () {
     const { config } = yield* TxConfig;
-    const outputBuilder = CML.TransactionOutputBuilder.new()
-      .with_address(yield* toCMLAddress(address, config.lucidConfig))
-      .next();
+    const cmlAddress = yield* toCMLAddress(address, config.lucidConfig);
+    const outputBuilder = withCMLScope((own) =>
+      own(
+        own(CML.TransactionOutputBuilder.new()).with_address(own(cmlAddress)),
+      ).next(),
+    );
 
-    if (Object.keys(assets).length == 0)
+    if (Object.keys(assets).length == 0) {
+      outputBuilder.free();
       yield* payError(ERROR_MESSAGE.EMPTY_ASSETS);
+    }
 
-    const value = assetsToValue(assets);
-    let outputResult = outputBuilder
-      .with_asset_and_min_required_coin(
-        value.multi_asset(),
-        config.lucidConfig.protocolParameters.coinsPerUtxoByte,
-      )
-      .build();
+    addOutput(config, outputBuilder, assets);
+  });
+
+/** Builds the output, records it, and frees the builder. */
+const addOutput = (
+  config: TxBuilder.TxBuilderConfig,
+  outputBuilder: CML.TransactionOutputAmountBuilder,
+  assets: Assets,
+): void =>
+  withCMLScope((own) => {
+    own(outputBuilder);
+    const value = own(assetsToValue(assets));
+    let outputResult = own(
+      own(
+        outputBuilder.with_asset_and_min_required_coin(
+          own(value.multi_asset()),
+          config.lucidConfig.protocolParameters.coinsPerUtxoByte,
+        ),
+      ).build(),
+    );
 
     const setLovelaces = assets["lovelace"];
     if (setLovelaces) {
-      const minLovelace = outputResult.output().amount().coin();
+      const minLovelace = own(own(outputResult.output()).amount()).coin();
       if (setLovelaces > minLovelace) {
-        outputResult = outputBuilder.with_value(value).build();
+        outputResult = own(own(outputBuilder.with_value(value)).build());
       }
     }
+    const output = own(outputResult.output());
     // Keep track of actual total output value
     config.totalOutputAssets = addAssets(
       config.totalOutputAssets,
-      valueToAssets(outputResult.output().amount()),
+      valueToAssets(own(output.amount())),
     );
-    config.payToOutputs = [
-      ...config.payToOutputs,
-      coreToTxOutput(outputResult.output()),
-    ];
+    config.payToOutputs = [...config.payToOutputs, coreToTxOutput(output)];
     config.txBuilder.add_output(outputResult);
   });
 
@@ -72,31 +89,7 @@ export const ToAddressWithData = (
     const outputBuilder = buildBaseOutput(address, outputDatum, scriptRef);
 
     assets ??= {};
-    const value = assetsToValue(assets);
-    let outputResult = outputBuilder
-      .with_asset_and_min_required_coin(
-        value.multi_asset(),
-        config.lucidConfig.protocolParameters.coinsPerUtxoByte,
-      )
-      .build();
-
-    const setLovelaces = assets["lovelace"];
-    if (setLovelaces) {
-      const minLovelace = outputResult.output().amount().coin();
-      if (setLovelaces > minLovelace) {
-        outputResult = outputBuilder.with_value(value).build();
-      }
-    }
-    // Keep track of actual total output value
-    config.totalOutputAssets = addAssets(
-      config.totalOutputAssets,
-      valueToAssets(outputResult.output().amount()),
-    );
-    config.payToOutputs = [
-      ...config.payToOutputs,
-      coreToTxOutput(outputResult.output()),
-    ];
-    config.txBuilder.add_output(outputResult);
+    addOutput(config, outputBuilder, assets);
   });
 
 /** Pay to a plutus script address with datum or scriptRef. */
@@ -107,48 +100,60 @@ export const ToContract = (
   scriptRef?: Script,
 ) => ToAddressWithData(address, outputDatum, assets, scriptRef);
 
+/** The returned amount builder belongs to the caller. */
 export const buildBaseOutput = (
   address: Address,
   outputDatum?: OutputDatum,
   scriptRef?: Script,
-) => {
-  let baseBuilder: CML.TransactionOutputBuilder;
-  const addressBuilder = CML.TransactionOutputBuilder.new().with_address(
-    CML.Address.from_bech32(address),
-  );
-  if (outputDatum) {
-    if (outputDatum.value.trim() === "") {
-      throw new Error(
-        "datum value is missing. Please provide a non-empty cbor hex data.",
-      );
-    }
-    switch (outputDatum.kind) {
-      case "hash": {
-        const datumOption = CML.DatumOption.new_hash(
-          CML.DatumHash.from_hex(outputDatum.value),
+): CML.TransactionOutputAmountBuilder =>
+  withCMLScope((own) => {
+    let baseBuilder: CML.TransactionOutputBuilder;
+    const addressBuilder = own(
+      own(CML.TransactionOutputBuilder.new()).with_address(
+        own(CML.Address.from_bech32(address)),
+      ),
+    );
+    if (outputDatum) {
+      if (outputDatum.value.trim() === "") {
+        throw new Error(
+          "datum value is missing. Please provide a non-empty cbor hex data.",
         );
-        baseBuilder = addressBuilder.with_data(datumOption);
-        break;
       }
-      case "asHash": {
-        const plutusData = CML.PlutusData.from_cbor_hex(outputDatum.value);
-        baseBuilder = addressBuilder.with_communication_data(plutusData);
-        break;
+      switch (outputDatum.kind) {
+        case "hash": {
+          const datumOption = own(
+            CML.DatumOption.new_hash(
+              own(CML.DatumHash.from_hex(outputDatum.value)),
+            ),
+          );
+          baseBuilder = own(addressBuilder.with_data(datumOption));
+          break;
+        }
+        case "asHash": {
+          const plutusData = own(
+            CML.PlutusData.from_cbor_hex(outputDatum.value),
+          );
+          baseBuilder = own(addressBuilder.with_communication_data(plutusData));
+          break;
+        }
+        case "inline": {
+          const plutusData = own(
+            CML.PlutusData.from_cbor_hex(outputDatum.value),
+          );
+          const datumOption = own(CML.DatumOption.new_datum(plutusData));
+          baseBuilder = own(addressBuilder.with_data(datumOption));
+          break;
+        }
+        default:
+          throw new Error(`Unknown outputDatum: ${outputDatum}`);
       }
-      case "inline": {
-        const plutusData = CML.PlutusData.from_cbor_hex(outputDatum.value);
-        const datumOption = CML.DatumOption.new_datum(plutusData);
-        baseBuilder = addressBuilder.with_data(datumOption);
-        break;
-      }
-      default:
-        throw new Error(`Unknown outputDatum: ${outputDatum}`);
+    } else {
+      baseBuilder = addressBuilder;
     }
-  } else {
-    baseBuilder = addressBuilder;
-  }
 
-  return scriptRef
-    ? baseBuilder.with_reference_script(toScriptRef(scriptRef)).next()
-    : baseBuilder.next();
-};
+    return scriptRef
+      ? own(
+          baseBuilder.with_reference_script(own(toScriptRef(scriptRef))),
+        ).next()
+      : baseBuilder.next();
+  });

--- a/packages/lucid/src/tx-builder/internal/Read.ts
+++ b/packages/lucid/src/tx-builder/internal/Read.ts
@@ -1,5 +1,6 @@
 import { Effect } from "effect";
 import { utxoToCore } from "@lucid-evolution/utils";
+import { withCMLScope } from "@lucid-evolution/core-utils";
 import { UTxO } from "@lucid-evolution/core-types";
 import { ERROR_MESSAGE, TxBuilderError } from "../../Errors.js";
 import { resolveDatum } from "./TxUtils.js";
@@ -20,7 +21,6 @@ export const readFrom = (utxos: UTxO[]) =>
         config.lucidConfig.provider,
       );
 
-      const coreUtxo = utxoToCore({ ...utxo, datum: resolvedDatum });
       const exists = config.readInputs.some(
         (input) =>
           input.txHash === utxo.txHash &&
@@ -28,7 +28,11 @@ export const readFrom = (utxos: UTxO[]) =>
       );
 
       if (!exists) {
-        config.txBuilder.add_reference_input(coreUtxo);
+        withCMLScope((own) =>
+          config.txBuilder.add_reference_input(
+            own(utxoToCore({ ...utxo, datum: resolvedDatum })),
+          ),
+        );
         // Store inputs for later use in the txBuilder
         config.readInputs.push(utxo);
       }

--- a/packages/lucid/src/tx-builder/internal/RedeemerContext.ts
+++ b/packages/lucid/src/tx-builder/internal/RedeemerContext.ts
@@ -20,6 +20,7 @@ import {
   fromCMLRedeemerTag,
 } from "@lucid-evolution/utils";
 import { CML } from "../../core.js";
+import { withCMLScope } from "@lucid-evolution/core-utils";
 import { TxBuilderError } from "../../Errors.js";
 import type { TxBuilderConfig } from "../TxBuilder.js";
 
@@ -214,10 +215,14 @@ export const resolveCanonicalInputs = (
   candidates: ReadonlyArray<UTxO>,
 ): Effect.Effect<UTxO[], TxBuilderError> =>
   Effect.gen(function* () {
-    const bodyInputs = tx.body().inputs();
+    const outRefs = withCMLScope((own) => {
+      const bodyInputs = own(own(tx.body()).inputs());
+      return Array.from({ length: bodyInputs.len() }, (_, i) =>
+        coreToOutRef(own(bodyInputs.get(i))),
+      );
+    });
     const inputs: UTxO[] = [];
-    for (let i = 0; i < bodyInputs.len(); i++) {
-      const outRef = coreToOutRef(bodyInputs.get(i));
+    for (const outRef of outRefs) {
       const resolved = findResolvedInput(outRef, candidates);
       if (!resolved) {
         yield* redeemerContextError(
@@ -235,11 +240,15 @@ export const resolveCanonicalReferenceInputs = (
   candidates: ReadonlyArray<UTxO>,
 ): Effect.Effect<UTxO[], TxBuilderError> =>
   Effect.gen(function* () {
-    const bodyInputs = tx.body().reference_inputs();
+    const outRefs = withCMLScope((own) => {
+      const bodyInputs = own(own(tx.body()).reference_inputs());
+      if (!bodyInputs) return [];
+      return Array.from({ length: bodyInputs.len() }, (_, i) =>
+        coreToOutRef(own(bodyInputs.get(i))),
+      );
+    });
     const inputs: UTxO[] = [];
-    if (!bodyInputs) return inputs;
-    for (let i = 0; i < bodyInputs.len(); i++) {
-      const outRef = coreToOutRef(bodyInputs.get(i));
+    for (const outRef of outRefs) {
       const resolved = findResolvedInput(outRef, candidates);
       if (!resolved) {
         yield* redeemerContextError(
@@ -252,66 +261,72 @@ export const resolveCanonicalReferenceInputs = (
     return inputs;
   });
 
-const deriveOutputs = (body: CML.TransactionBody): TxOutput[] => {
-  const outputs = body.outputs();
-  const result: TxOutput[] = [];
-  for (let i = 0; i < outputs.len(); i++) {
-    result.push(coreToTxOutput(outputs.get(i)));
-  }
-  return result;
-};
+const deriveOutputs = (body: CML.TransactionBody): TxOutput[] =>
+  withCMLScope((own) => {
+    const outputs = own(body.outputs());
+    const result: TxOutput[] = [];
+    for (let i = 0; i < outputs.len(); i++) {
+      result.push(coreToTxOutput(own(outputs.get(i))));
+    }
+    return result;
+  });
 
-const deriveMint = (body: CML.TransactionBody): Assets => {
-  const mint = body.mint();
-  const assets: Assets = {};
-  if (!mint) return assets;
-  const policies = mint.keys();
-  for (let i = 0; i < policies.len(); i++) {
-    const policy = policies.get(i);
-    const policyId = policy.to_hex();
-    const policyAssets = mint.get_assets(policy)!;
-    const assetNames = policyAssets.keys();
-    for (let j = 0; j < assetNames.len(); j++) {
-      const assetName = assetNames.get(j);
-      const quantity = policyAssets.get(assetName)!;
-      if (quantity !== 0n) {
-        assets[policyId + assetName.to_js_value()] = quantity;
+const deriveMint = (body: CML.TransactionBody): Assets =>
+  withCMLScope((own) => {
+    const mint = own(body.mint());
+    const assets: Assets = {};
+    if (!mint) return assets;
+    const policies = own(mint.keys());
+    for (let i = 0; i < policies.len(); i++) {
+      const policy = own(policies.get(i));
+      const policyId = policy.to_hex();
+      const policyAssets = own(mint.get_assets(policy)!);
+      const assetNames = own(policyAssets.keys());
+      for (let j = 0; j < assetNames.len(); j++) {
+        const assetName = own(assetNames.get(j));
+        const quantity = policyAssets.get(assetName)!;
+        if (quantity !== 0n) {
+          assets[policyId + assetName.to_js_value()] = quantity;
+        }
       }
     }
-  }
-  return assets;
-};
+    return assets;
+  });
 
-const deriveMintPolicyIds = (body: CML.TransactionBody): PolicyId[] => {
-  const mint = body.mint();
-  if (!mint) return [];
-  const policies = mint.keys();
-  const result: PolicyId[] = [];
-  for (let i = 0; i < policies.len(); i++) {
-    result.push(policies.get(i).to_hex());
-  }
-  return result;
-};
+const deriveMintPolicyIds = (body: CML.TransactionBody): PolicyId[] =>
+  withCMLScope((own) => {
+    const mint = own(body.mint());
+    if (!mint) return [];
+    const policies = own(mint.keys());
+    const result: PolicyId[] = [];
+    for (let i = 0; i < policies.len(); i++) {
+      result.push(own(policies.get(i)).to_hex());
+    }
+    return result;
+  });
 
 const deriveWithdrawals = (
   body: CML.TransactionBody,
-): RedeemerContext["withdrawals"] => {
-  const withdrawals = body.withdrawals();
-  if (!withdrawals) return [];
-  const rewardAddresses = withdrawals.keys();
-  const result: WithdrawalEntry[] = [];
-  for (let i = 0; i < rewardAddresses.len(); i++) {
-    const rewardAddress = rewardAddresses.get(i);
-    result.push({
-      rewardAddress: rewardAddress.to_address().to_bech32(undefined),
-      amount: withdrawals.get(rewardAddress)!,
-    });
-  }
-  return result;
-};
+): RedeemerContext["withdrawals"] =>
+  withCMLScope((own) => {
+    const withdrawals = own(body.withdrawals());
+    if (!withdrawals) return [];
+    const rewardAddresses = own(withdrawals.keys());
+    const result: WithdrawalEntry[] = [];
+    for (let i = 0; i < rewardAddresses.len(); i++) {
+      const rewardAddress = own(rewardAddresses.get(i));
+      result.push({
+        rewardAddress: own(rewardAddress.to_address()).to_bech32(undefined),
+        amount: withdrawals.get(rewardAddress)!,
+      });
+    }
+    return result;
+  });
 
 const redeemerKeyBytes = (tag: CML.RedeemerTag, index: bigint): Uint8Array =>
-  CML.RedeemerKey.new(tag, index).to_canonical_cbor_bytes();
+  withCMLScope((own) =>
+    own(CML.RedeemerKey.new(tag, index)).to_canonical_cbor_bytes(),
+  );
 
 const cmlVoterKey = (voter: CML.Voter): string => voter.to_canonical_cbor_hex();
 
@@ -326,43 +341,55 @@ const indexToSafeNumber = (index: bigint): number | undefined => {
 export const proposalProcedureForRedeemerIndex = (
   tx: CML.Transaction,
   index: bigint,
-): CML.ProposalProcedure | undefined => {
-  const proposals = tx.body().proposal_procedures();
-  if (!proposals) return undefined;
-  const target = indexToSafeNumber(index);
-  if (target === undefined) return undefined;
+): CML.ProposalProcedure | undefined =>
+  withCMLScope((own) => {
+    const proposals = own(own(tx.body()).proposal_procedures());
+    if (!proposals) return undefined;
+    const target = indexToSafeNumber(index);
+    if (target === undefined) return undefined;
 
-  return target < proposals.len() ? proposals.get(target) : undefined;
-};
+    return target < proposals.len() ? proposals.get(target) : undefined;
+  });
 
 export const voterForRedeemerIndex = (
   tx: CML.Transaction,
   index: bigint,
-): CML.Voter | undefined => {
-  const voters = tx.body().voting_procedures()?.keys();
-  if (!voters) return undefined;
-  const target = indexToSafeNumber(index);
-  if (target === undefined) return undefined;
+): CML.Voter | undefined =>
+  withCMLScope((own) => {
+    const voters = own(own(own(tx.body()).voting_procedures())?.keys());
+    if (!voters) return undefined;
+    const target = indexToSafeNumber(index);
+    if (target === undefined) return undefined;
 
-  return target < voters.len() ? voters.get(target) : undefined;
+    return target < voters.len() ? voters.get(target) : undefined;
+  });
+
+/**
+ * The builder-side (tag, index) of a redeemer, kept as plain values so the map
+ * that carries them owns no CML memory.
+ */
+export type BuilderRedeemerKey = {
+  readonly tag: CML.RedeemerTag;
+  readonly index: bigint;
 };
 
 export type GovernanceRedeemerNormalization = Readonly<{
   transaction: CML.Transaction;
-  builderKeyByLedgerKey: ReadonlyMap<string, CML.RedeemerWitnessKey>;
+  builderKeyByLedgerKey: ReadonlyMap<string, BuilderRedeemerKey>;
 }>;
 
 const voterIndexByKey = (
   tx: CML.Transaction,
   voterKey: string,
-): bigint | undefined => {
-  const voters = tx.body().voting_procedures()?.keys();
-  if (!voters) return undefined;
-  for (let i = 0; i < voters.len(); i++) {
-    if (cmlVoterKey(voters.get(i)) === voterKey) return BigInt(i);
-  }
-  return undefined;
-};
+): bigint | undefined =>
+  withCMLScope((own) => {
+    const voters = own(own(own(tx.body()).voting_procedures())?.keys());
+    if (!voters) return undefined;
+    for (let i = 0; i < voters.len(); i++) {
+      if (cmlVoterKey(own(voters.get(i))) === voterKey) return BigInt(i);
+    }
+    return undefined;
+  });
 
 const governanceIndex = (
   tx: CML.Transaction,
@@ -381,12 +408,14 @@ const governanceIndex = (
   if (tag === "propose") {
     if (proposalWitnessIndices.length === 0) return rawIndex;
     const ledgerIndex = proposalWitnessIndices[witnessIndex];
-    const proposals = tx.body().proposal_procedures();
+    const proposalCount = withCMLScope((own) =>
+      own(own(tx.body()).proposal_procedures())?.len(),
+    );
     if (
       ledgerIndex === undefined ||
-      !proposals ||
+      proposalCount === undefined ||
       ledgerIndex < 0n ||
-      ledgerIndex >= BigInt(proposals.len())
+      ledgerIndex >= BigInt(proposalCount)
     ) {
       throw redeemerContextError(
         `Unable to map proposing redeemer index ${rawIndex} to a proposal procedure`,
@@ -409,92 +438,97 @@ export const normalizeGovernanceRedeemerIndices = (
   tx: CML.Transaction,
   voteWitnessKeys: readonly string[],
   proposalWitnessIndices: readonly bigint[],
-): GovernanceRedeemerNormalization => {
-  const transaction = CML.Transaction.from_cbor_bytes(tx.to_cbor_bytes());
-  const ledgerIndexTransaction = CML.Transaction.from_cbor_bytes(
-    tx.to_canonical_cbor_bytes(),
-  );
-  const witnessSet = transaction.witness_set();
-  const redeemers = witnessSet.redeemers();
-  const builderKeyByLedgerKey = new Map<string, CML.RedeemerWitnessKey>();
-  if (!redeemers) return { transaction, builderKeyByLedgerKey };
-
-  const seen = new Set<string>();
-  const normalizeKey = (tag: CML.RedeemerTag, index: bigint): bigint => {
-    const lucidTag = fromCMLRedeemerTag(tag);
-    const normalizedIndex = governanceIndex(
-      ledgerIndexTransaction,
-      lucidTag,
-      index,
-      voteWitnessKeys,
-      proposalWitnessIndices,
+): GovernanceRedeemerNormalization =>
+  withCMLScope((own) => {
+    // The returned transaction is always a fresh copy; the caller owns it.
+    const transaction = CML.Transaction.from_cbor_bytes(tx.to_cbor_bytes());
+    const ledgerIndexTransaction = own(
+      CML.Transaction.from_cbor_bytes(tx.to_canonical_cbor_bytes()),
     );
-    const ledgerKey = `${lucidTag}:${normalizedIndex}`;
-    if (seen.has(ledgerKey)) {
-      throw redeemerContextError(
-        `Multiple builder redeemers map to ledger purpose ${ledgerKey}`,
+    const witnessSet = own(transaction.witness_set());
+    const redeemers = own(witnessSet.redeemers());
+    const builderKeyByLedgerKey = new Map<string, BuilderRedeemerKey>();
+    if (!redeemers) return { transaction, builderKeyByLedgerKey };
+
+    const seen = new Set<string>();
+    const normalizeKey = (tag: CML.RedeemerTag, index: bigint): bigint => {
+      const lucidTag = fromCMLRedeemerTag(tag);
+      const normalizedIndex = governanceIndex(
+        ledgerIndexTransaction,
+        lucidTag,
+        index,
+        voteWitnessKeys,
+        proposalWitnessIndices,
       );
-    }
-    seen.add(ledgerKey);
-    builderKeyByLedgerKey.set(
-      ledgerKey,
-      CML.RedeemerWitnessKey.new(tag, index),
-    );
-    return normalizedIndex;
-  };
-
-  const legacy = redeemers.as_arr_legacy_redeemer();
-  if (legacy) {
-    const normalized = CML.LegacyRedeemerList.new();
-    for (let i = 0; i < legacy.len(); i++) {
-      const redeemer = legacy.get(i);
-      normalized.add(
-        CML.LegacyRedeemer.new(
-          redeemer.tag(),
-          normalizeKey(redeemer.tag(), redeemer.index()),
-          redeemer.data(),
-          redeemer.ex_units(),
+      const ledgerKey = `${lucidTag}:${normalizedIndex}`;
+      if (seen.has(ledgerKey)) {
+        throw redeemerContextError(
+          `Multiple builder redeemers map to ledger purpose ${ledgerKey}`,
+        );
+      }
+      seen.add(ledgerKey);
+      builderKeyByLedgerKey.set(ledgerKey, { tag, index });
+      return normalizedIndex;
+    };
+    const withNormalizedWitnessSet = (): GovernanceRedeemerNormalization => {
+      own(transaction);
+      return {
+        // `Transaction.new` takes ownership of the auxiliary data.
+        transaction: CML.Transaction.new(
+          own(transaction.body()),
+          witnessSet,
+          transaction.is_valid(),
+          transaction.auxiliary_data(),
         ),
-      );
-    }
-    witnessSet.set_redeemers(CML.Redeemers.new_arr_legacy_redeemer(normalized));
-    return {
-      transaction: CML.Transaction.new(
-        transaction.body(),
-        witnessSet,
-        transaction.is_valid(),
-        transaction.auxiliary_data(),
-      ),
-      builderKeyByLedgerKey,
+        builderKeyByLedgerKey,
+      };
     };
-  }
 
-  const map = redeemers.as_map_redeemer_key_to_redeemer_val();
-  if (map) {
-    const normalized = CML.MapRedeemerKeyToRedeemerVal.new();
-    const keys = map.keys();
-    for (let i = 0; i < keys.len(); i++) {
-      const key = keys.get(i);
-      normalized.insert(
-        CML.RedeemerKey.new(key.tag(), normalizeKey(key.tag(), key.index())),
-        map.get(key)!,
+    const legacy = own(redeemers.as_arr_legacy_redeemer());
+    if (legacy) {
+      const normalized = own(CML.LegacyRedeemerList.new());
+      for (let i = 0; i < legacy.len(); i++) {
+        const redeemer = own(legacy.get(i));
+        normalized.add(
+          own(
+            CML.LegacyRedeemer.new(
+              redeemer.tag(),
+              normalizeKey(redeemer.tag(), redeemer.index()),
+              own(redeemer.data()),
+              own(redeemer.ex_units()),
+            ),
+          ),
+        );
+      }
+      witnessSet.set_redeemers(
+        own(CML.Redeemers.new_arr_legacy_redeemer(normalized)),
       );
+      return withNormalizedWitnessSet();
     }
-    witnessSet.set_redeemers(
-      CML.Redeemers.new_map_redeemer_key_to_redeemer_val(normalized),
-    );
-    return {
-      transaction: CML.Transaction.new(
-        transaction.body(),
-        witnessSet,
-        transaction.is_valid(),
-        transaction.auxiliary_data(),
-      ),
-      builderKeyByLedgerKey,
-    };
-  }
-  return { transaction, builderKeyByLedgerKey };
-};
+
+    const map = own(redeemers.as_map_redeemer_key_to_redeemer_val());
+    if (map) {
+      const normalized = own(CML.MapRedeemerKeyToRedeemerVal.new());
+      const keys = own(map.keys());
+      for (let i = 0; i < keys.len(); i++) {
+        const key = own(keys.get(i));
+        normalized.insert(
+          own(
+            CML.RedeemerKey.new(
+              key.tag(),
+              normalizeKey(key.tag(), key.index()),
+            ),
+          ),
+          own(map.get(key)!),
+        );
+      }
+      witnessSet.set_redeemers(
+        own(CML.Redeemers.new_map_redeemer_key_to_redeemer_val(normalized)),
+      );
+      return withNormalizedWitnessSet();
+    }
+    return { transaction, builderKeyByLedgerKey };
+  });
 
 const compareBytes = (a: Uint8Array, b: Uint8Array): number => {
   if (a.length !== b.length) return a.length - b.length;
@@ -504,48 +538,62 @@ const compareBytes = (a: Uint8Array, b: Uint8Array): number => {
   return 0;
 };
 
+/**
+ * The `data` and `exUnits` of every entry belong to the caller; release them
+ * with `freeCanonicalRedeemerEntries` once they have been read.
+ */
 export const canonicalRedeemerEntries = (
   redeemers: CML.Redeemers,
-): CanonicalRedeemerEntry[] => {
-  const entries: CanonicalRedeemerEntry[] = [];
+): CanonicalRedeemerEntry[] =>
+  withCMLScope((own) => {
+    const entries: CanonicalRedeemerEntry[] = [];
 
-  const legacyRedeemers = redeemers.as_arr_legacy_redeemer();
-  if (legacyRedeemers) {
-    for (let i = 0; i < legacyRedeemers.len(); i++) {
-      const redeemer = legacyRedeemers.get(i);
-      const cmlTag = redeemer.tag();
-      const index = redeemer.index();
-      entries.push({
-        tag: fromCMLRedeemerTag(cmlTag),
-        index,
-        data: redeemer.data(),
-        exUnits: redeemer.ex_units(),
-        sortKey: redeemerKeyBytes(cmlTag, index),
-      });
+    const legacyRedeemers = own(redeemers.as_arr_legacy_redeemer());
+    if (legacyRedeemers) {
+      for (let i = 0; i < legacyRedeemers.len(); i++) {
+        const redeemer = own(legacyRedeemers.get(i));
+        const cmlTag = redeemer.tag();
+        const index = redeemer.index();
+        entries.push({
+          tag: fromCMLRedeemerTag(cmlTag),
+          index,
+          data: redeemer.data(),
+          exUnits: redeemer.ex_units(),
+          sortKey: redeemerKeyBytes(cmlTag, index),
+        });
+      }
     }
-  }
 
-  const mapRedeemers = redeemers.as_map_redeemer_key_to_redeemer_val();
-  if (mapRedeemers) {
-    const keys = mapRedeemers.keys();
-    for (let i = 0; i < keys.len(); i++) {
-      const key = keys.get(i);
-      const value = mapRedeemers.get(key)!;
-      const cmlTag = key.tag();
-      const index = key.index();
-      entries.push({
-        tag: fromCMLRedeemerTag(cmlTag),
-        index,
-        data: value.data(),
-        exUnits: value.ex_units(),
-        sortKey: redeemerKeyBytes(cmlTag, index),
-      });
+    const mapRedeemers = own(redeemers.as_map_redeemer_key_to_redeemer_val());
+    if (mapRedeemers) {
+      const keys = own(mapRedeemers.keys());
+      for (let i = 0; i < keys.len(); i++) {
+        const key = own(keys.get(i));
+        const value = own(mapRedeemers.get(key)!);
+        const cmlTag = key.tag();
+        const index = key.index();
+        entries.push({
+          tag: fromCMLRedeemerTag(cmlTag),
+          index,
+          data: value.data(),
+          exUnits: value.ex_units(),
+          sortKey: redeemerKeyBytes(cmlTag, index),
+        });
+      }
     }
-  }
 
-  return entries.sort((left, right) =>
-    compareBytes(left.sortKey, right.sortKey),
-  );
+    return entries.sort((left, right) =>
+      compareBytes(left.sortKey, right.sortKey),
+    );
+  });
+
+export const freeCanonicalRedeemerEntries = (
+  entries: ReadonlyArray<CanonicalRedeemerEntry>,
+): void => {
+  for (const entry of entries) {
+    entry.data.free();
+    entry.exUnits.free();
+  }
 };
 
 const deriveRedeemerPurposes = (
@@ -555,9 +603,12 @@ const deriveRedeemerPurposes = (
   withdrawals: RedeemerContext["withdrawals"],
 ): Effect.Effect<RedeemerPurpose[], TxBuilderError> =>
   Effect.gen(function* () {
-    const redeemers = tx.witness_set().redeemers();
-    if (!redeemers) return [];
-    const entries = canonicalRedeemerEntries(redeemers);
+    const entries = withCMLScope((own) => {
+      const redeemers = own(own(tx.witness_set()).redeemers());
+      return redeemers ? canonicalRedeemerEntries(redeemers) : [];
+    });
+    // Only tags and indices are read below.
+    freeCanonicalRedeemerEntries(entries);
     const purposes: RedeemerPurpose[] = [];
     const finalKeys = new Set<string>();
 
@@ -620,23 +671,19 @@ const deriveRedeemerPurposes = (
           purposes.push({ tag, index, redeemerListIndex });
           break;
         case "propose": {
-          const proposal = proposalProcedureForRedeemerIndex(tx, index);
-          purposes.push({
-            tag,
-            index,
-            proposalKey: proposal ? cmlProposalKey(proposal) : undefined,
-            redeemerListIndex,
+          const proposalKey = withCMLScope((own) => {
+            const proposal = own(proposalProcedureForRedeemerIndex(tx, index));
+            return proposal ? cmlProposalKey(proposal) : undefined;
           });
+          purposes.push({ tag, index, proposalKey, redeemerListIndex });
           break;
         }
         case "vote": {
-          const voter = voterForRedeemerIndex(tx, index);
-          purposes.push({
-            tag,
-            index,
-            voterKey: voter ? cmlVoterKey(voter) : undefined,
-            redeemerListIndex,
+          const voterKey = withCMLScope((own) => {
+            const voter = own(voterForRedeemerIndex(tx, index));
+            return voter ? cmlVoterKey(voter) : undefined;
           });
+          purposes.push({ tag, index, voterKey, redeemerListIndex });
           break;
         }
       }
@@ -668,6 +715,7 @@ export const buildCanonicalRedeemerInfo = (
       mintPolicyIds,
       withdrawals,
     );
+    canonicalTx.free();
 
     const inputIndices = new Map<string, bigint>();
     inputs.forEach((input, index) => {
@@ -879,26 +927,30 @@ export const redeemerMapsEqual = (
   return true;
 };
 
-export const transactionFixedPointFingerprint = (
-  tx: CML.Transaction,
-): string => {
-  const body = tx.body().to_canonical_cbor_hex();
-  const redeemers = tx.witness_set().redeemers();
-  const redeemerData: string[] = [];
-  const redeemerExUnits: string[] = [];
-  if (redeemers) {
-    for (const redeemer of canonicalRedeemerEntries(redeemers)) {
-      const index = redeemer.index.toString();
-      redeemerData.push(
-        `${redeemer.tag}:${index}:${redeemer.data.to_canonical_cbor_hex()}`,
-      );
-      redeemerExUnits.push(
-        `${redeemer.tag}:${index}:${redeemer.exUnits.mem()}:${redeemer.exUnits.steps()}`,
-      );
+export const transactionFixedPointFingerprint = (tx: CML.Transaction): string =>
+  withCMLScope((own) => {
+    const body = own(tx.body()).to_canonical_cbor_hex();
+    const redeemers = own(own(tx.witness_set()).redeemers());
+    const redeemerData: string[] = [];
+    const redeemerExUnits: string[] = [];
+    if (redeemers) {
+      const entries = canonicalRedeemerEntries(redeemers);
+      try {
+        for (const redeemer of entries) {
+          const index = redeemer.index.toString();
+          redeemerData.push(
+            `${redeemer.tag}:${index}:${redeemer.data.to_canonical_cbor_hex()}`,
+          );
+          redeemerExUnits.push(
+            `${redeemer.tag}:${index}:${redeemer.exUnits.mem()}:${redeemer.exUnits.steps()}`,
+          );
+        }
+      } finally {
+        freeCanonicalRedeemerEntries(entries);
+      }
     }
-  }
-  return `${body}|${redeemerData.join(",")}|${redeemerExUnits.join(",")}`;
-};
+    return `${body}|${redeemerData.join(",")}|${redeemerExUnits.join(",")}`;
+  });
 
 export const normalizeEvalUTxO = ({
   datumHash,

--- a/packages/lucid/src/tx-builder/internal/Signer.ts
+++ b/packages/lucid/src/tx-builder/internal/Signer.ts
@@ -10,6 +10,7 @@ import * as CML from "@anastasia-labs/cardano-multiplatform-lib-nodejs";
 import { ERROR_MESSAGE, TxBuilderError } from "../../Errors.js";
 import { validateAddressDetails } from "./TxUtils.js";
 import { TxConfig } from "./Service.js";
+import { withCMLScope } from "@lucid-evolution/core-utils";
 
 export const addSignerError = (cause: unknown) =>
   new TxBuilderError({ cause: `{ Signer: ${cause} }` });
@@ -47,5 +48,9 @@ export const addSigner = (address: Address | RewardAddress) =>
 export const addSignerKey = (keyHash: PaymentKeyHash | StakeKeyHash) =>
   Effect.gen(function* () {
     const { config } = yield* TxConfig;
-    config.txBuilder.add_required_signer(CML.Ed25519KeyHash.from_hex(keyHash));
+    withCMLScope((own) =>
+      config.txBuilder.add_required_signer(
+        own(CML.Ed25519KeyHash.from_hex(keyHash)),
+      ),
+    );
   });

--- a/packages/lucid/src/tx-builder/internal/TxUtils.ts
+++ b/packages/lucid/src/tx-builder/internal/TxUtils.ts
@@ -2,6 +2,7 @@ import * as CML from "@anastasia-labs/cardano-multiplatform-lib-nodejs";
 import { CBORHex } from "../types.js";
 import { Effect, pipe } from "effect";
 import { networkToId, getAddressDetails } from "@lucid-evolution/utils";
+import { withCMLScope } from "@lucid-evolution/core-utils";
 import {
   Address,
   AddressDetails,
@@ -31,23 +32,33 @@ export const toCMLAddress = (
   Effect.gen(function* ($) {
     const { type } = yield* validateAddressDetails(address, lucidConfig);
     return type === "Byron"
-      ? CML.ByronAddress.from_base58(address).to_address()
+      ? withCMLScope((own) =>
+          own(CML.ByronAddress.from_base58(address)).to_address(),
+        )
       : CML.Address.from_bech32(address);
   });
 
 export const toV1 = (script: string) =>
-  CML.PlutusScript.from_v1(CML.PlutusV1Script.from_cbor_hex(script));
+  withCMLScope((own) =>
+    CML.PlutusScript.from_v1(own(CML.PlutusV1Script.from_cbor_hex(script))),
+  );
 
 export const toV2 = (script: string) =>
-  CML.PlutusScript.from_v2(CML.PlutusV2Script.from_cbor_hex(script));
+  withCMLScope((own) =>
+    CML.PlutusScript.from_v2(own(CML.PlutusV2Script.from_cbor_hex(script))),
+  );
 
 export const toV3 = (script: string) =>
-  CML.PlutusScript.from_v3(CML.PlutusV3Script.from_cbor_hex(script));
+  withCMLScope((own) =>
+    CML.PlutusScript.from_v3(own(CML.PlutusV3Script.from_cbor_hex(script))),
+  );
 
 export const toPartial = (script: CML.PlutusScript, redeemer: CBORHex) =>
-  CML.PartialPlutusWitness.new(
-    CML.PlutusScriptWitness.new_script(script),
-    CML.PlutusData.from_cbor_hex(redeemer),
+  withCMLScope((own) =>
+    CML.PartialPlutusWitness.new(
+      own(CML.PlutusScriptWitness.new_script(script)),
+      own(CML.PlutusData.from_cbor_hex(redeemer)),
+    ),
   );
 
 export const handleRedeemerBuilder = (

--- a/packages/lucid/src/tx-sign-builder/TxSignBuilder.ts
+++ b/packages/lucid/src/tx-sign-builder/TxSignBuilder.ts
@@ -1,4 +1,5 @@
 import { CML, makeReturn } from "../core.js";
+import { withCMLScope } from "@lucid-evolution/core-utils";
 import { LucidConfig } from "../lucid-evolution/LucidEvolution.js";
 import { Effect } from "effect";
 import * as S from "@effect/schema/Schema";
@@ -111,35 +112,41 @@ export const makeTxSignBuilder = (
     slotConfig?: SlotConfig;
   } = {},
 ): TxSignBuilder => {
-  const redeemers = tx.witness_set().redeemers();
-  const exUnits = { cpu: 0, mem: 0 };
-  if (redeemers) {
-    const arrLegacyRedeemer = redeemers?.as_arr_legacy_redeemer();
-    if (arrLegacyRedeemer) {
-      for (let i = 0; i < arrLegacyRedeemer.len(); i++) {
-        const redeemer = arrLegacyRedeemer.get(i);
-        exUnits.cpu += parseInt(redeemer.ex_units().steps().toString());
-        exUnits.mem += parseInt(redeemer.ex_units().mem().toString());
+  const exUnits = withCMLScope((own) => {
+    const totals = { cpu: 0, mem: 0 };
+    const add = (units: CML.ExUnits) => {
+      own(units);
+      totals.cpu += parseInt(units.steps().toString());
+      totals.mem += parseInt(units.mem().toString());
+    };
+    const redeemers = own(own(tx.witness_set()).redeemers());
+    if (redeemers) {
+      const arrLegacyRedeemer = own(redeemers.as_arr_legacy_redeemer());
+      if (arrLegacyRedeemer) {
+        for (let i = 0; i < arrLegacyRedeemer.len(); i++) {
+          add(own(arrLegacyRedeemer.get(i)).ex_units());
+        }
+      }
+      const mapRedeemerKeyToRedeemerVal = own(
+        redeemers.as_map_redeemer_key_to_redeemer_val(),
+      );
+      if (mapRedeemerKeyToRedeemerVal) {
+        const keys = own(mapRedeemerKeyToRedeemerVal.keys());
+        for (let i = 0; i < (keys.len() || 0); i++) {
+          const key = own(keys.get(i));
+          const value = own(mapRedeemerKeyToRedeemerVal.get(key));
+          add(value!.ex_units());
+        }
       }
     }
-    const mapRedeemerKeyToRedeemerVal =
-      redeemers?.as_map_redeemer_key_to_redeemer_val();
-    if (mapRedeemerKeyToRedeemerVal) {
-      const keys = mapRedeemerKeyToRedeemerVal.keys();
-      for (let i = 0; i < (keys.len() || 0); i++) {
-        const key = keys.get(i);
-        const value = mapRedeemerKeyToRedeemerVal.get(key);
-        exUnits.cpu += parseInt(value!.ex_units().steps().toString());
-        exUnits.mem += parseInt(value!.ex_units().mem().toString());
-      }
-    }
-  }
+    return totals;
+  });
   const config: TxSignBuilderConfig = {
     txComplete: tx,
     witnessSetBuilder: CML.TransactionWitnessSetBuilder.new(),
     programs: [],
     wallet: wallet,
-    fee: parseInt(tx.body().fee().toString()),
+    fee: withCMLScope((own) => parseInt(own(tx.body()).fee().toString())),
     exUnits: exUnits,
     resolvedInputs: options.resolvedInputs ?? [],
     slotConfig: options.slotConfig,
@@ -197,7 +204,10 @@ export const makeTxSignBuilder = (
       makeScriptContexts(config.txComplete, scriptContextOptions(options)),
     toJSON: () =>
       S.decodeUnknownSync(S.parseJson(S.Object))(config.txComplete.to_json()),
-    toHash: () => CML.hash_transaction(config.txComplete.body()).to_hex(),
+    toHash: () =>
+      withCMLScope((own) =>
+        own(CML.hash_transaction(own(config.txComplete.body()))).to_hex(),
+      ),
     complete: () =>
       makeReturn(CompleteTxSigner.completeTxSigner(config)).unsafeRun(),
     completeProgram: () => CompleteTxSigner.completeTxSigner(config),

--- a/packages/lucid/src/tx-sign-builder/internal/CompleteTxSigner.ts
+++ b/packages/lucid/src/tx-sign-builder/internal/CompleteTxSigner.ts
@@ -8,28 +8,33 @@ import {
 import * as TxSignBuilder from "../TxSignBuilder.js";
 import * as TxSubmitBuilder from "../../tx-submit/TxSubmit.js";
 import { signError } from "./Sign.js";
+import { withCMLScope } from "@lucid-evolution/core-utils";
 
 export const completeTxSigner = (
   config: TxSignBuilder.TxSignBuilderConfig,
 ): Effect.Effect<TxSubmitBuilder.TxSigned, TransactionSignError> =>
   Effect.gen(function* () {
     yield* Effect.all(config.programs, { concurrency: "unbounded" });
-    const plutus_datums = config.txComplete.witness_set().plutus_datums();
-    // TODO: currently add_existing does not support add_plutus_datums
-    // https://github.com/dcSpark/cardano-multiplatform-lib/pull/350/files
-    config.witnessSetBuilder.add_existing(config.txComplete.witness_set());
-    if (plutus_datums) {
-      for (let i = 0; i < plutus_datums.len(); i++) {
-        config.witnessSetBuilder.add_plutus_datum(plutus_datums.get(i));
+    const signedTx = withCMLScope((own) => {
+      const witnessSet = own(config.txComplete.witness_set());
+      const plutus_datums = own(witnessSet.plutus_datums());
+      // TODO: currently add_existing does not support add_plutus_datums
+      // https://github.com/dcSpark/cardano-multiplatform-lib/pull/350/files
+      config.witnessSetBuilder.add_existing(witnessSet);
+      if (plutus_datums) {
+        for (let i = 0; i < plutus_datums.len(); i++) {
+          // `add_plutus_datum` takes ownership of the datum.
+          config.witnessSetBuilder.add_plutus_datum(plutus_datums.get(i));
+        }
       }
-    }
-    const txWitnessSet = config.witnessSetBuilder.build();
-    const signedTx = CML.Transaction.new(
-      config.txComplete.body(),
-      txWitnessSet,
-      true,
-      config.txComplete.auxiliary_data(),
-    );
+      // `Transaction.new` takes ownership of the auxiliary data.
+      return CML.Transaction.new(
+        own(config.txComplete.body()),
+        own(config.witnessSetBuilder.build()),
+        true,
+        config.txComplete.auxiliary_data(),
+      );
+    });
     const wallet = yield* pipe(
       Effect.fromNullable(config.wallet),
       Effect.orElseFail(() => signError(ERROR_MESSAGE.MISSING_WALLET)),

--- a/packages/lucid/test/specs/tx-chaining.ts
+++ b/packages/lucid/test/specs/tx-chaining.ts
@@ -128,7 +128,7 @@ export const readRefInputTwice = Effect.gen(function* () {
     .completeProgram();
   const txSign = yield* txCompose.sign.withWallet().completeProgram();
   yield* txSign.submitProgram();
-});
+}).pipe(withLogRetry, Effect.orDie);
 
 const fetchForOwner = (utxos: UTxO[], ownerKeyHash: PaymentKeyHash) =>
   utxos.filter((value) => {

--- a/packages/plutus/src/data.ts
+++ b/packages/plutus/src/data.ts
@@ -9,7 +9,12 @@ import * as TypeBox from "@sinclair/typebox";
 //   Type,
 // } from "@sinclair/typebox";
 import { Datum, Exact, Json, Redeemer } from "@lucid-evolution/core-types";
-import { fromHex, fromText, toHex } from "@lucid-evolution/core-utils";
+import {
+  fromHex,
+  fromText,
+  toHex,
+  withCMLScope,
+} from "@lucid-evolution/core-utils";
 import * as CML from "@anastasia-labs/cardano-multiplatform-lib-nodejs";
 export * from "@sinclair/typebox";
 
@@ -285,50 +290,57 @@ function to<T = Data>(
   options: { canonical?: boolean } = {},
 ): Datum | Redeemer {
   const { canonical = false } = options;
+  // CML containers clone what is added to them, so every intermediate
+  // PlutusData is freed as soon as it has been copied into its parent.
   function serialize(data: Data): CML.PlutusData {
     try {
-      if (typeof data === "bigint") {
-        return CML.PlutusData.new_integer(
-          CML.BigInteger.from_str(data.toString()),
-        );
-      } else if (typeof data === "string") {
-        return CML.PlutusData.new_bytes(fromHex(data));
-      } else if (data instanceof Constr) {
-        const { index, fields } = data;
-        const plutusList = CML.PlutusDataList.new();
+      return withCMLScope((own) => {
+        if (typeof data === "bigint") {
+          return CML.PlutusData.new_integer(
+            own(CML.BigInteger.from_str(data.toString())),
+          );
+        } else if (typeof data === "string") {
+          return CML.PlutusData.new_bytes(fromHex(data));
+        } else if (data instanceof Constr) {
+          const { index, fields } = data;
+          const plutusList = own(CML.PlutusDataList.new());
 
-        fields.forEach((field) => plutusList.add(serialize(field)));
+          fields.forEach((field) => plutusList.add(own(serialize(field))));
 
-        return CML.PlutusData.new_constr_plutus_data(
-          CML.ConstrPlutusData.new(
-            CML.BigInteger.from_str(index.toString()).as_u64()!,
-            plutusList,
-          ),
-        );
-      } else if (data instanceof Array) {
-        const plutusList = CML.PlutusDataList.new();
+          const alternative = own(CML.BigInteger.from_str(index.toString()));
+          return CML.PlutusData.new_constr_plutus_data(
+            own(CML.ConstrPlutusData.new(alternative.as_u64()!, plutusList)),
+          );
+        } else if (data instanceof Array) {
+          const plutusList = own(CML.PlutusDataList.new());
 
-        data.forEach((arg) => plutusList.add(serialize(arg)));
+          data.forEach((arg) => plutusList.add(own(serialize(arg))));
 
-        return CML.PlutusData.new_list(plutusList);
-      } else if (data instanceof Map) {
-        const plutusMap = CML.PlutusMap.new();
+          return CML.PlutusData.new_list(plutusList);
+        } else if (data instanceof Map) {
+          const plutusMap = own(CML.PlutusMap.new());
 
-        for (const [key, value] of data.entries()) {
-          plutusMap.set(serialize(key), serialize(value));
+          for (const [key, value] of data.entries()) {
+            plutusMap.set(own(serialize(key)), own(serialize(value)));
+          }
+
+          return CML.PlutusData.new_map(plutusMap);
         }
-
-        return CML.PlutusData.new_map(plutusMap);
-      }
-      throw new Error("Unsupported type");
+        throw new Error("Unsupported type");
+      });
     } catch (error) {
       throw new Error("Could not serialize the data: " + error);
     }
   }
   const d = type ? castTo<T>(data, type) : (data as Data);
-  return canonical
-    ? (serialize(d).to_canonical_cbor_hex() as Datum | Redeemer)
-    : (serialize(d).to_cardano_node_format().to_cbor_hex() as Datum | Redeemer);
+  return withCMLScope((own) => {
+    const serialized = own(serialize(d));
+    return canonical
+      ? (serialized.to_canonical_cbor_hex() as Datum | Redeemer)
+      : (own(serialized.to_cardano_node_format()).to_cbor_hex() as
+          | Datum
+          | Redeemer);
+  });
 }
 
 /**
@@ -336,38 +348,45 @@ function to<T = Data>(
  *  Or apply a shape and cast the cbor encoded data to a certain type.
  */
 function from<T = Data>(raw: Datum | Redeemer, type?: T): T {
+  // `data` is borrowed from the caller; every accessor result is a fresh CML
+  // copy and is freed once it has been converted.
   function deserialize(data: CML.PlutusData): Data {
-    if (data.kind() === 0) {
-      const constr = data.as_constr_plutus_data()!;
-      const l = constr.fields();
-      const desL = [];
-      for (let i = 0; i < l.len(); i++) {
-        desL.push(deserialize(l.get(i)));
+    return withCMLScope((own) => {
+      if (data.kind() === 0) {
+        const constr = own(data.as_constr_plutus_data()!);
+        const l = own(constr.fields());
+        const desL = [];
+        for (let i = 0; i < l.len(); i++) {
+          desL.push(deserialize(own(l.get(i))));
+        }
+        return new Constr(parseInt(constr.alternative().toString()), desL);
+      } else if (data.kind() === 1) {
+        const m = own(data.as_map()!);
+        const desM: Map<Data, Data> = new Map();
+        const keys = own(m.keys());
+        for (let i = 0; i < keys.len(); i++) {
+          const key = own(keys.get(i));
+          desM.set(deserialize(key), deserialize(own(m.get(key)!)));
+        }
+        return desM;
+      } else if (data.kind() === 2) {
+        const l = own(data.as_list()!);
+        const desL = [];
+        for (let i = 0; i < l.len(); i++) {
+          desL.push(deserialize(own(l.get(i))));
+        }
+        return desL;
+      } else if (data.kind() === 3) {
+        return BigInt(own(data.as_integer()!).to_str());
+      } else if (data.kind() === 4) {
+        return toHex(data.as_bytes()!);
       }
-      return new Constr(parseInt(constr.alternative().toString()), desL);
-    } else if (data.kind() === 1) {
-      const m = data.as_map()!;
-      const desM: Map<Data, Data> = new Map();
-      const keys = m.keys();
-      for (let i = 0; i < keys.len(); i++) {
-        desM.set(deserialize(keys.get(i)), deserialize(m.get(keys.get(i))!));
-      }
-      return desM;
-    } else if (data.kind() === 2) {
-      const l = data.as_list()!;
-      const desL = [];
-      for (let i = 0; i < l.len(); i++) {
-        desL.push(deserialize(l.get(i)));
-      }
-      return desL;
-    } else if (data.kind() === 3) {
-      return BigInt(data.as_integer()!.to_str());
-    } else if (data.kind() === 4) {
-      return toHex(data.as_bytes()!);
-    }
-    throw new Error("Unsupported type");
+      throw new Error("Unsupported type");
+    });
   }
-  const data = deserialize(CML.PlutusData.from_cbor_hex(raw));
+  const data = withCMLScope((own) =>
+    deserialize(own(CML.PlutusData.from_cbor_hex(raw))),
+  );
 
   return type ? castFrom<T>(data, type) : (data as T);
 }

--- a/packages/provider/src/emulator.ts
+++ b/packages/provider/src/emulator.ts
@@ -30,7 +30,7 @@ import {
   PROTOCOL_PARAMETERS_DEFAULT,
 } from "@lucid-evolution/utils";
 import { coreToUtxo, getAddressDetails } from "@lucid-evolution/utils";
-import { fromHex } from "@lucid-evolution/core-utils";
+import { freeCML, fromHex, withCMLScope } from "@lucid-evolution/core-utils";
 import { walletFromSeed } from "@lucid-evolution/wallet";
 
 /** Concatentation of txHash + outputIndex */
@@ -440,9 +440,11 @@ export class Emulator implements Provider {
     const datumTable = (() => {
       const table: Record<DatumHash, Datum> = {};
       for (let i = 0; i < (datums?.len() || 0); i++) {
-        const datum = datums!.get(i);
-        const datumHash = CML.hash_plutus_data(datum).to_hex();
-        table[datumHash] = datum.to_cbor_hex();
+        withCMLScope((own) => {
+          const datum = own(datums!.get(i));
+          const datumHash = own(CML.hash_plutus_data(datum)).to_hex();
+          table[datumHash] = datum.to_cbor_hex();
+        });
       }
       return table;
     })();
@@ -450,84 +452,92 @@ export class Emulator implements Provider {
     const consumedHashes = new Set();
 
     // Witness keys
-    const keyHashes = (() => {
-      const keyHashes = [];
-      for (let i = 0; i < (witnesses.vkeywitnesses()?.len() || 0); i++) {
-        const witness = witnesses.vkeywitnesses()!.get(i);
-        const publicKey = witness.vkey();
-        const keyHash = publicKey.hash().to_hex();
+    const keyHashes = withCMLScope((own) => {
+      const keyHashes: string[] = [];
+      const vkeyWitnesses = own(witnesses.vkeywitnesses());
+      for (let i = 0; i < (vkeyWitnesses?.len() || 0); i++) {
+        withCMLScope((own) => {
+          const witness = own(vkeyWitnesses!.get(i));
+          const publicKey = own(witness.vkey());
+          const keyHash = own(publicKey.hash()).to_hex();
 
-        if (!publicKey.verify(fromHex(txHash), witness.ed25519_signature())) {
-          throw new Error(`Invalid vkey witness. Key hash: ${keyHash}`);
-        }
-        keyHashes.push(keyHash);
+          if (
+            !publicKey.verify(fromHex(txHash), own(witness.ed25519_signature()))
+          ) {
+            throw new Error(`Invalid vkey witness. Key hash: ${keyHash}`);
+          }
+          keyHashes.push(keyHash);
+        });
       }
       return keyHashes;
-    })();
+    });
 
     // We only need this to verify native scripts. The check happens in the CML.
     const edKeyHashes = CML.Ed25519KeyHashList.new();
     keyHashes.forEach((keyHash) =>
-      edKeyHashes.add(CML.Ed25519KeyHash.from_hex(keyHash)),
+      withCMLScope((own) =>
+        edKeyHashes.add(own(CML.Ed25519KeyHash.from_hex(keyHash))),
+      ),
     );
 
-    const nativeHashes = (() => {
-      const scriptHashes = [];
+    const nativeHashes = withCMLScope((own) => {
+      const scriptHashes: string[] = [];
+      const nativeScripts = own(witnesses.native_scripts());
 
-      for (let i = 0; i < (witnesses.native_scripts()?.len() || 0); i++) {
-        const witness = witnesses.native_scripts()!.get(i);
-        const scriptHash = witness.hash().to_hex();
-        // TODO:  Fix verify
+      for (let i = 0; i < (nativeScripts?.len() || 0); i++) {
+        withCMLScope((own) => {
+          const witness = own(nativeScripts!.get(i));
+          const scriptHash = own(witness.hash()).to_hex();
+          // TODO:  Fix verify
 
-        if (
-          !witness.verify(
-            Number.isInteger(lowerBound)
-              ? CML.BigInteger.from_str(lowerBound!.toString()).to_js_value()
-              : undefined,
-            Number.isInteger(upperBound)
-              ? CML.BigInteger.from_str(upperBound!.toString()).to_js_value()
-              : undefined,
-            edKeyHashes,
-          )
-        ) {
-          throw new Error(
-            `Invalid native script witness. Script hash: ${scriptHash}`,
-          );
-        }
-        for (let i = 0; i < witness.get_required_signers().len(); i++) {
-          const keyHash = witness.get_required_signers().get(i).to_hex();
-          consumedHashes.add(keyHash);
-        }
-        scriptHashes.push(scriptHash);
+          if (
+            !witness.verify(
+              Number.isInteger(lowerBound) ? BigInt(lowerBound!) : undefined,
+              Number.isInteger(upperBound) ? BigInt(upperBound!) : undefined,
+              edKeyHashes,
+            )
+          ) {
+            throw new Error(
+              `Invalid native script witness. Script hash: ${scriptHash}`,
+            );
+          }
+          const requiredSigners = own(witness.get_required_signers());
+          for (let j = 0; j < requiredSigners.len(); j++) {
+            const keyHash = own(requiredSigners.get(j)).to_hex();
+            consumedHashes.add(keyHash);
+          }
+          scriptHashes.push(scriptHash);
+        });
       }
       return scriptHashes;
-    })();
+    });
+    edKeyHashes.free();
 
     const nativeHashesOptional: Record<ScriptHash, CML.NativeScript> = {};
     const plutusHashesOptional: ScriptHash[] = [];
 
-    const plutusHashes = (() => {
-      const scriptHashes = [];
-      for (let i = 0; i < (witnesses.plutus_v1_scripts()?.len() || 0); i++) {
-        const script = witnesses.plutus_v1_scripts()!.get(i);
-        const scriptHash = script.hash().to_hex();
-
-        scriptHashes.push(scriptHash);
-      }
-      for (let i = 0; i < (witnesses.plutus_v2_scripts()?.len() || 0); i++) {
-        const script = witnesses.plutus_v2_scripts()!.get(i);
-        const scriptHash = script.hash().to_hex();
-
-        scriptHashes.push(scriptHash);
-      }
-      for (let i = 0; i < (witnesses.plutus_v3_scripts()?.len() || 0); i++) {
-        const script = witnesses.plutus_v3_scripts()!.get(i);
-        const scriptHash = script.hash().to_hex();
-
-        scriptHashes.push(scriptHash);
-      }
+    const plutusHashes = withCMLScope((own) => {
+      const scriptHashes: ScriptHash[] = [];
+      const collectHashes = (
+        scripts:
+          | CML.PlutusV1ScriptList
+          | CML.PlutusV2ScriptList
+          | CML.PlutusV3ScriptList
+          | undefined,
+      ) => {
+        own(scripts);
+        for (let i = 0; i < (scripts?.len() || 0); i++) {
+          withCMLScope((own) => {
+            const script = own(scripts!.get(i));
+            scriptHashes.push(own(script.hash()).to_hex());
+          });
+        }
+      };
+      collectHashes(witnesses.plutus_v1_scripts());
+      collectHashes(witnesses.plutus_v2_scripts());
+      collectHashes(witnesses.plutus_v3_scripts());
       return scriptHashes;
-    })();
+    });
 
     const inputs = body.inputs();
     // inputs.sort();
@@ -541,9 +551,10 @@ export class Emulator implements Provider {
 
     // Check existence of inputs and look for script refs.
     for (let i = 0; i < inputs.len(); i++) {
-      const input = inputs.get(i);
-
-      const outRef = input.transaction_id().to_hex() + input.index().toString();
+      const outRef = withCMLScope((own) => {
+        const input = own(inputs.get(i));
+        return own(input.transaction_id()).to_hex() + input.index().toString();
+      });
 
       const entryLedger = this.ledger[outRef];
 
@@ -598,12 +609,15 @@ export class Emulator implements Provider {
 
       resolvedInputs.push({ entry, type });
     }
+    inputs.free();
 
     // Check existence of reference inputs and look for script refs.
-    for (let i = 0; i < (body.reference_inputs()?.len() || 0); i++) {
-      const input = body.reference_inputs()!.get(i);
-
-      const outRef = input.transaction_id().to_hex() + input.index().toString();
+    const referenceInputs = body.reference_inputs();
+    for (let i = 0; i < (referenceInputs?.len() || 0); i++) {
+      const outRef = withCMLScope((own) => {
+        const input = own(referenceInputs!.get(i));
+        return own(input.transaction_id()).to_hex() + input.index().toString();
+      });
 
       const entry = this.ledger[outRef] || this.mempool[outRef];
 
@@ -652,6 +666,7 @@ export class Emulator implements Provider {
 
       if (entry.utxo.datumHash) consumedHashes.add(entry.utxo.datumHash);
     }
+    referenceInputs?.free();
 
     type Tag = "Spend" | "Mint" | "Cert" | "Reward" | "Proposing" | "Voting";
 
@@ -753,10 +768,12 @@ export class Emulator implements Provider {
 
     // Check collateral inputs
 
-    for (let i = 0; i < (body.collateral_inputs()?.len() || 0); i++) {
-      const input = body.collateral_inputs()!.get(i);
-
-      const outRef = input.transaction_id().to_hex() + input.index().toString();
+    const collateralInputs = body.collateral_inputs();
+    for (let i = 0; i < (collateralInputs?.len() || 0); i++) {
+      const outRef = withCMLScope((own) => {
+        const input = own(collateralInputs!.get(i));
+        return own(input.transaction_id()).to_hex() + input.index().toString();
+      });
 
       const entry = this.ledger[outRef] || this.mempool[outRef];
 
@@ -775,6 +792,7 @@ export class Emulator implements Provider {
       }
       checkAndConsumeHash(paymentCredential!, null, null);
     }
+    collateralInputs?.free();
 
     // Check required signers
 
@@ -1118,16 +1136,21 @@ export class Emulator implements Provider {
     });
 
     // Create outputs and consume datum hashes
-    const outputs = (() => {
+    const outputs = withCMLScope((own) => {
       const collected = [];
-      for (let i = 0; i < body.outputs().len(); i++) {
-        const output = body.outputs().get(i);
-        const unspentOutput = CML.TransactionUnspentOutput.new(
-          CML.TransactionInput.new(
-            CML.TransactionHash.from_hex(txHash),
-            CML.BigInteger.from_str(i.toString()).to_js_value(),
+      const bodyOutputs = own(body.outputs());
+      for (let i = 0; i < bodyOutputs.len(); i++) {
+        const output = own(bodyOutputs.get(i));
+        const unspentOutput = own(
+          CML.TransactionUnspentOutput.new(
+            own(
+              CML.TransactionInput.new(
+                own(CML.TransactionHash.from_hex(txHash)),
+                BigInt(i),
+              ),
+            ),
+            output,
           ),
-          output,
         );
 
         const utxo = coreToUtxo(unspentOutput);
@@ -1140,7 +1163,7 @@ export class Emulator implements Provider {
         });
       }
       return collected;
-    })();
+    });
 
     // Check consumed witnesses
 
@@ -1231,6 +1254,7 @@ export class Emulator implements Provider {
 
     this.transactionHistory[txHash] = { status: "pending" };
 
+    freeCML(datums, witnesses, body, desTx);
     return Promise.resolve(txHash);
   }
 
@@ -1238,49 +1262,54 @@ export class Emulator implements Provider {
     tx: Transaction,
     additionalUTxOs?: UTxO[],
   ): Promise<EvalRedeemer[]> {
-    const desTx = CML.Transaction.from_cbor_hex(tx);
-    const redeemers = desTx.witness_set().redeemers();
-    if (!redeemers) {
-      return [];
-    }
-    let evalRedeemers: EvalRedeemer[] = [];
-    const arrLegacyRedeemer = redeemers.as_arr_legacy_redeemer();
-    if (arrLegacyRedeemer) {
-      for (let i = 0; i < arrLegacyRedeemer.len(); i++) {
-        const legacyRedeemer = arrLegacyRedeemer.get(i);
-        evalRedeemers.push({
-          ex_units: {
-            mem: Number(legacyRedeemer.ex_units().mem()),
-            steps: Number(legacyRedeemer.ex_units().steps()),
-          },
-          redeemer_index: Number(legacyRedeemer.index()),
-          redeemer_tag: fromCMLRedeemerTag(legacyRedeemer.tag()),
-        });
+    return withCMLScope((own) => {
+      const desTx = own(CML.Transaction.from_cbor_hex(tx));
+      const redeemers = own(own(desTx.witness_set()).redeemers());
+      if (!redeemers) {
+        return [];
       }
-      return evalRedeemers;
-    }
-    const mapRedeemerKeyToRedeemerVal =
-      redeemers.as_map_redeemer_key_to_redeemer_val();
-    if (mapRedeemerKeyToRedeemerVal) {
-      const keys = mapRedeemerKeyToRedeemerVal.keys();
-
-      for (let i = 0; i < keys.len(); i++) {
-        const key = keys.get(i);
-        const redeemerVal = mapRedeemerKeyToRedeemerVal.get(key);
-        if (redeemerVal) {
+      const evalRedeemers: EvalRedeemer[] = [];
+      const arrLegacyRedeemer = own(redeemers.as_arr_legacy_redeemer());
+      if (arrLegacyRedeemer) {
+        for (let i = 0; i < arrLegacyRedeemer.len(); i++) {
+          const legacyRedeemer = own(arrLegacyRedeemer.get(i));
+          const exUnits = own(legacyRedeemer.ex_units());
           evalRedeemers.push({
             ex_units: {
-              mem: Number(redeemerVal.ex_units().mem()),
-              steps: Number(redeemerVal.ex_units().steps()),
+              mem: Number(exUnits.mem()),
+              steps: Number(exUnits.steps()),
             },
-            redeemer_index: Number(key.index),
-            redeemer_tag: fromCMLRedeemerTag(key.tag()),
+            redeemer_index: Number(legacyRedeemer.index()),
+            redeemer_tag: fromCMLRedeemerTag(legacyRedeemer.tag()),
           });
         }
+        return evalRedeemers;
+      }
+      const mapRedeemerKeyToRedeemerVal = own(
+        redeemers.as_map_redeemer_key_to_redeemer_val(),
+      );
+      if (mapRedeemerKeyToRedeemerVal) {
+        const keys = own(mapRedeemerKeyToRedeemerVal.keys());
+
+        for (let i = 0; i < keys.len(); i++) {
+          const key = own(keys.get(i));
+          const redeemerVal = own(mapRedeemerKeyToRedeemerVal.get(key));
+          if (redeemerVal) {
+            const exUnits = own(redeemerVal.ex_units());
+            evalRedeemers.push({
+              ex_units: {
+                mem: Number(exUnits.mem()),
+                steps: Number(exUnits.steps()),
+              },
+              redeemer_index: Number(key.index()),
+              redeemer_tag: fromCMLRedeemerTag(key.tag()),
+            });
+          }
+        }
+        return evalRedeemers;
       }
       return evalRedeemers;
-    }
-    return evalRedeemers;
+    });
   }
 
   log() {

--- a/packages/utils/src/address.ts
+++ b/packages/utils/src/address.ts
@@ -6,6 +6,7 @@ import {
   CertificateValidator,
   WithdrawalValidator,
 } from "@lucid-evolution/core-types";
+import { CMLOwn, withCMLScope } from "@lucid-evolution/core-utils";
 import { CML } from "./core.js";
 import { networkToId } from "./network.js";
 import { validatorToScriptHash } from "./scripts.js";
@@ -26,18 +27,24 @@ export function credentialToRewardAddress(
   network: Network,
   stakeCredential: Credential,
 ): RewardAddress {
-  return CML.RewardAddress.new(
-    networkToId(network),
-    stakeCredential.type === "Key"
-      ? CML.Credential.new_pub_key(
-          CML.Ed25519KeyHash.from_hex(stakeCredential.hash),
-        )
-      : CML.Credential.new_script(
-          CML.ScriptHash.from_hex(stakeCredential.hash),
-        ),
-  )
-    .to_address()
-    .to_bech32(undefined);
+  return withCMLScope((own) => {
+    const credential =
+      stakeCredential.type === "Key"
+        ? own(
+            CML.Credential.new_pub_key(
+              own(CML.Ed25519KeyHash.from_hex(stakeCredential.hash)),
+            ),
+          )
+        : own(
+            CML.Credential.new_script(
+              own(CML.ScriptHash.from_hex(stakeCredential.hash)),
+            ),
+          );
+    const rewardAddress = own(
+      CML.RewardAddress.new(networkToId(network), credential),
+    );
+    return own(rewardAddress.to_address()).to_bech32(undefined);
+  });
 }
 
 export function validatorToRewardAddress(
@@ -45,161 +52,159 @@ export function validatorToRewardAddress(
   validator: CertificateValidator | WithdrawalValidator,
 ): RewardAddress {
   const validatorHash = validatorToScriptHash(validator);
-  return CML.RewardAddress.new(
-    networkToId(network),
-    CML.Credential.new_script(CML.ScriptHash.from_hex(validatorHash)),
-  )
-    .to_address()
-    .to_bech32(undefined);
+  return withCMLScope((own) => {
+    const credential = own(
+      CML.Credential.new_script(own(CML.ScriptHash.from_hex(validatorHash))),
+    );
+    const rewardAddress = own(
+      CML.RewardAddress.new(networkToId(network), credential),
+    );
+    return own(rewardAddress.to_address()).to_bech32(undefined);
+  });
 }
+
+const credentialDetails = (
+  credential: CML.Credential,
+  own: CMLOwn,
+): Credential =>
+  credential.kind() === 0
+    ? { type: "Key", hash: own(credential.as_pub_key()!).to_hex() }
+    : { type: "Script", hash: own(credential.as_script()!).to_hex() };
+
+const addressDetails = (
+  address: CML.Address,
+): AddressDetails["address"] & { networkId: number } => ({
+  networkId: address.network_id(),
+  bech32: address.to_bech32(undefined),
+  hex: address.to_hex(),
+});
 
 /** Address can be in Bech32 or Hex. */
 export function getAddressDetails(address: string): AddressDetails {
   // Base Address
   try {
-    const parsedAddress = CML.BaseAddress.from_address(
-      addressFromHexOrBech32(address),
-    )!;
-    const paymentCredential: Credential =
-      parsedAddress.payment().kind() === 0
-        ? {
-            type: "Key",
-            hash: parsedAddress.payment().as_pub_key()!.to_hex(),
-          }
-        : {
-            type: "Script",
-            hash: parsedAddress.payment().as_script()!.to_hex(),
-          };
-    const stakeCredential: Credential =
-      parsedAddress.stake().kind() === 0
-        ? {
-            type: "Key",
-            hash: parsedAddress.stake().as_pub_key()!.to_hex(),
-          }
-        : {
-            type: "Script",
-            hash: parsedAddress.stake().as_script()!.to_hex(),
-          };
-    return {
-      type: "Base",
-      networkId: parsedAddress.to_address().network_id(),
-      address: {
-        bech32: parsedAddress.to_address().to_bech32(undefined),
-        hex: parsedAddress.to_address().to_hex(),
-      },
-      paymentCredential,
-      stakeCredential,
-    };
+    return withCMLScope((own) => {
+      const parsedAddress = own(
+        CML.BaseAddress.from_address(own(addressFromHexOrBech32(address))),
+      )!;
+      const paymentCredential = credentialDetails(
+        own(parsedAddress.payment()),
+        own,
+      );
+      const stakeCredential = credentialDetails(
+        own(parsedAddress.stake()),
+        own,
+      );
+      const { networkId, ...details } = addressDetails(
+        own(parsedAddress.to_address()),
+      );
+      return {
+        type: "Base",
+        networkId,
+        address: details,
+        paymentCredential,
+        stakeCredential,
+      };
+    });
   } catch (_e) {
     /* pass */
   }
 
   // Enterprise Address
   try {
-    const parsedAddress = CML.EnterpriseAddress.from_address(
-      addressFromHexOrBech32(address),
-    )!;
-    const paymentCredential: Credential =
-      parsedAddress.payment().kind() === 0
-        ? {
-            type: "Key",
-            hash: parsedAddress.payment().as_pub_key()!.to_hex(),
-          }
-        : {
-            type: "Script",
-            hash: parsedAddress.payment().as_script()!.to_hex(),
-          };
-    return {
-      type: "Enterprise",
-      networkId: parsedAddress.to_address().network_id(),
-      address: {
-        bech32: parsedAddress.to_address().to_bech32(undefined),
-        hex: parsedAddress.to_address().to_hex(),
-      },
-      paymentCredential,
-    };
+    return withCMLScope((own) => {
+      const parsedAddress = own(
+        CML.EnterpriseAddress.from_address(
+          own(addressFromHexOrBech32(address)),
+        ),
+      )!;
+      const paymentCredential = credentialDetails(
+        own(parsedAddress.payment()),
+        own,
+      );
+      const { networkId, ...details } = addressDetails(
+        own(parsedAddress.to_address()),
+      );
+      return {
+        type: "Enterprise",
+        networkId,
+        address: details,
+        paymentCredential,
+      };
+    });
   } catch (_e) {
     /* pass */
   }
 
   // Pointer Address
   try {
-    const parsedAddress = CML.PointerAddress.from_address(
-      addressFromHexOrBech32(address),
-    )!;
-    const paymentCredential: Credential =
-      parsedAddress?.payment().kind() === 0
-        ? {
-            type: "Key",
-            hash: parsedAddress.payment().as_pub_key()!.to_hex(),
-          }
-        : {
-            type: "Script",
-            hash: parsedAddress.payment().as_script()!.to_hex(),
-          };
-    return {
-      type: "Pointer",
-      networkId: parsedAddress.to_address().network_id(),
-      address: {
-        bech32: parsedAddress.to_address().to_bech32(undefined),
-        hex: parsedAddress.to_address().to_hex(),
-      },
-      paymentCredential,
-    };
+    return withCMLScope((own) => {
+      const parsedAddress = own(
+        CML.PointerAddress.from_address(own(addressFromHexOrBech32(address))),
+      )!;
+      const paymentCredential = credentialDetails(
+        own(parsedAddress.payment()),
+        own,
+      );
+      const { networkId, ...details } = addressDetails(
+        own(parsedAddress.to_address()),
+      );
+      return {
+        type: "Pointer",
+        networkId,
+        address: details,
+        paymentCredential,
+      };
+    });
   } catch (_e) {
     /* pass */
   }
 
   // Reward Address
   try {
-    const parsedAddress = CML.RewardAddress.from_address(
-      addressFromHexOrBech32(address),
-    )!;
-    const stakeCredential: Credential =
-      parsedAddress.payment().kind() === 0
-        ? {
-            type: "Key",
-            hash: parsedAddress.payment().as_pub_key()!.to_hex(),
-          }
-        : {
-            type: "Script",
-            hash: parsedAddress.payment().as_script()!.to_hex(),
-          };
-    return {
-      type: "Reward",
-      networkId: parsedAddress.to_address().network_id(),
-      address: {
-        bech32: parsedAddress.to_address().to_bech32(undefined),
-        hex: parsedAddress.to_address().to_hex(),
-      },
-      stakeCredential,
-    };
+    return withCMLScope((own) => {
+      const parsedAddress = own(
+        CML.RewardAddress.from_address(own(addressFromHexOrBech32(address))),
+      )!;
+      const stakeCredential = credentialDetails(
+        own(parsedAddress.payment()),
+        own,
+      );
+      const { networkId, ...details } = addressDetails(
+        own(parsedAddress.to_address()),
+      );
+      return { type: "Reward", networkId, address: details, stakeCredential };
+    });
   } catch (_e) {
     /* pass */
   }
 
   // Limited support for Byron addresses
   try {
-    const parsedAddress = ((address: string): CML.ByronAddress => {
-      try {
-        return CML.ByronAddress.from_cbor_hex(address);
-      } catch (_e) {
-        try {
-          return CML.ByronAddress.from_base58(address);
-        } catch (_e) {
-          throw new Error("Could not deserialize address.");
-        }
-      }
-    })(address);
+    return withCMLScope((own) => {
+      const parsedAddress = own(
+        ((address: string): CML.ByronAddress => {
+          try {
+            return CML.ByronAddress.from_cbor_hex(address);
+          } catch (_e) {
+            try {
+              return CML.ByronAddress.from_base58(address);
+            } catch (_e) {
+              throw new Error("Could not deserialize address.");
+            }
+          }
+        })(address),
+      );
 
-    return {
-      type: "Byron",
-      networkId: parsedAddress.content().network_id(),
-      address: {
-        bech32: "",
-        hex: parsedAddress.to_address().to_hex(),
-      },
-    };
+      return {
+        type: "Byron",
+        networkId: own(parsedAddress.content()).network_id(),
+        address: {
+          bech32: "",
+          hex: own(parsedAddress.to_address()).to_hex(),
+        },
+      };
+    });
   } catch (_e) {
     /* pass */
   }

--- a/packages/utils/src/scripts.ts
+++ b/packages/utils/src/scripts.ts
@@ -21,7 +21,7 @@ import {
   UPLCConst,
   UPLCProgram,
 } from "@harmoniclabs/uplc";
-import { fromHex, toHex } from "@lucid-evolution/core-utils";
+import { fromHex, toHex, withCMLScope } from "@lucid-evolution/core-utils";
 import { decode } from "cbor-x";
 import { dataFromCbor } from "@harmoniclabs/plutus-data";
 
@@ -31,118 +31,137 @@ export function validatorToAddress(
   stakeCredential?: Credential,
 ): Address {
   const validatorHash = validatorToScriptHash(validator);
-  if (stakeCredential) {
-    return CML.BaseAddress.new(
-      networkToId(network),
-      CML.Credential.new_script(CML.ScriptHash.from_hex(validatorHash)),
-      stakeCredential.type === "Key"
-        ? CML.Credential.new_pub_key(
-            CML.Ed25519KeyHash.from_hex(stakeCredential.hash),
-          )
-        : CML.Credential.new_script(
-            CML.ScriptHash.from_hex(stakeCredential.hash),
-          ),
-    )
-      .to_address()
-      .to_bech32(undefined);
-  } else {
-    return CML.EnterpriseAddress.new(
-      networkToId(network),
-      CML.Credential.new_script(CML.ScriptHash.from_hex(validatorHash)),
-    )
-      .to_address()
-      .to_bech32(undefined);
-  }
+  return withCMLScope((own) => {
+    const paymentCredential = own(
+      CML.Credential.new_script(own(CML.ScriptHash.from_hex(validatorHash))),
+    );
+    if (stakeCredential) {
+      const stake =
+        stakeCredential.type === "Key"
+          ? own(
+              CML.Credential.new_pub_key(
+                own(CML.Ed25519KeyHash.from_hex(stakeCredential.hash)),
+              ),
+            )
+          : own(
+              CML.Credential.new_script(
+                own(CML.ScriptHash.from_hex(stakeCredential.hash)),
+              ),
+            );
+      const address = own(
+        CML.BaseAddress.new(networkToId(network), paymentCredential, stake),
+      );
+      return own(address.to_address()).to_bech32(undefined);
+    }
+    const address = own(
+      CML.EnterpriseAddress.new(networkToId(network), paymentCredential),
+    );
+    return own(address.to_address()).to_bech32(undefined);
+  });
 }
 
 export function validatorToScriptHash(validator: Validator): ScriptHash {
-  switch (validator.type) {
-    case "Native":
-      return CML.NativeScript.from_cbor_hex(validator.script).hash().to_hex();
-    case "PlutusV1":
-      return CML.PlutusScript.from_v1(
-        CML.PlutusV1Script.from_cbor_hex(
-          applyDoubleCborEncoding(validator.script),
-        ),
-      )
-        .hash()
-        .to_hex();
-    case "PlutusV2":
-      return CML.PlutusScript.from_v2(
-        CML.PlutusV2Script.from_cbor_hex(
-          applyDoubleCborEncoding(validator.script),
-        ),
-      )
-        .hash()
-        .to_hex();
-    case "PlutusV3":
-      return CML.PlutusScript.from_v3(
-        CML.PlutusV3Script.from_cbor_hex(
-          applyDoubleCborEncoding(validator.script),
-        ),
-      )
-        .hash()
-        .to_hex();
-    default:
-      throw new Error("No variant matched");
-  }
+  return withCMLScope((own) => {
+    switch (validator.type) {
+      case "Native":
+        return own(
+          own(CML.NativeScript.from_cbor_hex(validator.script)).hash(),
+        ).to_hex();
+      case "PlutusV1": {
+        const script = own(
+          CML.PlutusV1Script.from_cbor_hex(
+            applyDoubleCborEncoding(validator.script),
+          ),
+        );
+        return own(own(CML.PlutusScript.from_v1(script)).hash()).to_hex();
+      }
+      case "PlutusV2": {
+        const script = own(
+          CML.PlutusV2Script.from_cbor_hex(
+            applyDoubleCborEncoding(validator.script),
+          ),
+        );
+        return own(own(CML.PlutusScript.from_v2(script)).hash()).to_hex();
+      }
+      case "PlutusV3": {
+        const script = own(
+          CML.PlutusV3Script.from_cbor_hex(
+            applyDoubleCborEncoding(validator.script),
+          ),
+        );
+        return own(own(CML.PlutusScript.from_v3(script)).hash()).to_hex();
+      }
+      default:
+        throw new Error("No variant matched");
+    }
+  });
 }
 
 export function toScriptRef(script: Script): CML.Script {
-  switch (script.type) {
-    case "Native":
-      return CML.Script.new_native(
-        CML.NativeScript.from_cbor_hex(script.script),
-      );
-    case "PlutusV1":
-      return CML.Script.new_plutus_v1(
-        CML.PlutusV1Script.from_cbor_hex(
-          applyDoubleCborEncoding(script.script),
-        ),
-      );
-    case "PlutusV2":
-      return CML.Script.new_plutus_v2(
-        CML.PlutusV2Script.from_cbor_hex(
-          applyDoubleCborEncoding(script.script),
-        ),
-      );
-    case "PlutusV3":
-      return CML.Script.new_plutus_v3(
-        CML.PlutusV3Script.from_cbor_hex(
-          applyDoubleCborEncoding(script.script),
-        ),
-      );
-    default:
-      throw new Error("No variant matched.");
-  }
+  return withCMLScope((own) => {
+    switch (script.type) {
+      case "Native":
+        return CML.Script.new_native(
+          own(CML.NativeScript.from_cbor_hex(script.script)),
+        );
+      case "PlutusV1":
+        return CML.Script.new_plutus_v1(
+          own(
+            CML.PlutusV1Script.from_cbor_hex(
+              applyDoubleCborEncoding(script.script),
+            ),
+          ),
+        );
+      case "PlutusV2":
+        return CML.Script.new_plutus_v2(
+          own(
+            CML.PlutusV2Script.from_cbor_hex(
+              applyDoubleCborEncoding(script.script),
+            ),
+          ),
+        );
+      case "PlutusV3":
+        return CML.Script.new_plutus_v3(
+          own(
+            CML.PlutusV3Script.from_cbor_hex(
+              applyDoubleCborEncoding(script.script),
+            ),
+          ),
+        );
+      default:
+        throw new Error("No variant matched.");
+    }
+  });
 }
 
 export function fromScriptRef(scriptRef: CML.Script): Script {
-  const kind = scriptRef.kind();
-  switch (kind) {
-    case 0:
-      return {
-        type: "Native",
-        script: scriptRef.as_native()!.to_cbor_hex(),
-      };
-    case 1:
-      return {
-        type: "PlutusV1",
-        script: scriptRef.as_plutus_v1()!.to_cbor_hex(),
-      };
-    case 2:
-      return {
-        type: "PlutusV2",
-        script: scriptRef.as_plutus_v2()!.to_cbor_hex(),
-      };
-    case 3:
-      return {
-        type: "PlutusV3",
-        script: scriptRef.as_plutus_v3()!.to_cbor_hex(),
-      };
-    default:
-      throw new Error("No variant matched.");
-  }
+  return withCMLScope((own) => {
+    const kind = scriptRef.kind();
+    switch (kind) {
+      case 0:
+        return {
+          type: "Native",
+          script: own(scriptRef.as_native()!).to_cbor_hex(),
+        };
+      case 1:
+        return {
+          type: "PlutusV1",
+          script: own(scriptRef.as_plutus_v1()!).to_cbor_hex(),
+        };
+      case 2:
+        return {
+          type: "PlutusV2",
+          script: own(scriptRef.as_plutus_v2()!).to_cbor_hex(),
+        };
+      case 3:
+        return {
+          type: "PlutusV3",
+          script: own(scriptRef.as_plutus_v3()!).to_cbor_hex(),
+        };
+      default:
+        throw new Error("No variant matched.");
+    }
+  });
 }
 
 export function mintingPolicyToId(mintingPolicy: MintingPolicy): PolicyId {

--- a/packages/utils/src/utxo.ts
+++ b/packages/utils/src/utxo.ts
@@ -1,31 +1,31 @@
 import { Assets, OutRef, TxOutput, UTxO } from "@lucid-evolution/core-types";
+import { CMLOwn, withCMLScope } from "@lucid-evolution/core-utils";
 import { CML } from "./core.js";
 import { fromScriptRef, toScriptRef } from "./scripts.js";
 import { assetsToValue, valueToAssets } from "./value.js";
 
-export const utxoToTransactionOutput = (utxo: UTxO) => {
-  return buildOutput(utxo)
-    .with_value(assetsToValue(utxo.assets))
-    .build()
-    .output();
-};
+export const utxoToTransactionOutput = (utxo: UTxO): CML.TransactionOutput =>
+  withCMLScope((own) => {
+    const value = own(assetsToValue(utxo.assets));
+    const builder = own(buildOutput(utxo, own).with_value(value));
+    return own(builder.build()).output();
+  });
 
-export const utxoToTransactionInput = (utxo: UTxO) => {
-  return CML.TransactionInput.new(
-    CML.TransactionHash.from_hex(utxo.txHash),
-    BigInt(utxo.outputIndex),
+export const utxoToTransactionInput = (utxo: UTxO): CML.TransactionInput =>
+  withCMLScope((own) =>
+    CML.TransactionInput.new(
+      own(CML.TransactionHash.from_hex(utxo.txHash)),
+      BigInt(utxo.outputIndex),
+    ),
   );
-};
 
-export const utxoToCore = (utxo: UTxO): CML.TransactionUnspentOutput => {
-  const out = utxoToTransactionOutput(utxo);
-  const utxoCore = CML.TransactionUnspentOutput.new(
-    utxoToTransactionInput(utxo),
-    out,
+export const utxoToCore = (utxo: UTxO): CML.TransactionUnspentOutput =>
+  withCMLScope((own) =>
+    CML.TransactionUnspentOutput.new(
+      own(utxoToTransactionInput(utxo)),
+      own(utxoToTransactionOutput(utxo)),
+    ),
   );
-  // out.free();
-  return utxoCore;
-};
 
 export function utxosToCores(utxos: UTxO[]): CML.TransactionUnspentOutput[] {
   const result: CML.TransactionUnspentOutput[] = [];
@@ -37,11 +37,10 @@ export function utxosToCores(utxos: UTxO[]): CML.TransactionUnspentOutput[] {
 
 //TODO: test coreToUtxo -> utxoToCore strict equality
 export function coreToUtxo(coreUtxo: CML.TransactionUnspentOutput): UTxO {
-  const utxo = {
-    ...coreToOutRef(coreUtxo.input()),
-    ...coreToTxOutput(coreUtxo.output()),
-  };
-  return utxo;
+  return withCMLScope((own) => ({
+    ...coreToOutRef(own(coreUtxo.input())),
+    ...coreToTxOutput(own(coreUtxo.output())),
+  }));
 }
 
 export function coresToUtxos(utxos: CML.TransactionUnspentOutput[]): UTxO[] {
@@ -53,10 +52,10 @@ export function coresToUtxos(utxos: CML.TransactionUnspentOutput[]): UTxO[] {
 }
 
 export function coreToOutRef(input: CML.TransactionInput): OutRef {
-  return {
-    txHash: input.transaction_id().to_hex(),
+  return withCMLScope((own) => ({
+    txHash: own(input.transaction_id()).to_hex(),
     outputIndex: parseInt(input.index().toString()),
-  };
+  }));
 }
 
 export function coresToOutRefs(inputs: CML.TransactionInput[]): OutRef[] {
@@ -68,13 +67,17 @@ export function coresToOutRefs(inputs: CML.TransactionInput[]): OutRef[] {
 }
 
 export function coreToTxOutput(output: CML.TransactionOutput): TxOutput {
-  return {
-    assets: valueToAssets(output.amount()),
-    address: output.address().to_bech32(undefined),
-    datumHash: output.datum()?.as_hash()?.to_hex(),
-    datum: output.datum()?.as_datum()?.to_cbor_hex(),
-    scriptRef: output.script_ref() && fromScriptRef(output.script_ref()!),
-  };
+  return withCMLScope((own) => {
+    const datum = own(output.datum());
+    const scriptRef = own(output.script_ref());
+    return {
+      assets: valueToAssets(own(output.amount())),
+      address: own(output.address()).to_bech32(undefined),
+      datumHash: own(datum?.as_hash())?.to_hex(),
+      datum: own(datum?.as_datum())?.to_cbor_hex(),
+      scriptRef: scriptRef && fromScriptRef(scriptRef),
+    };
+  });
 }
 
 export function coresToTxOutputs(outputs: CML.TransactionOutput[]): TxOutput[] {
@@ -254,40 +257,50 @@ export const calculateMinLovelaceFromUTxO = (
   coinsPerUtxoByte: bigint,
   utxo: UTxO,
 ): bigint =>
-  buildOutput(utxo)
-    .with_asset_and_min_required_coin(
-      assetsToValue(utxo.assets).multi_asset(),
-      coinsPerUtxoByte,
-    )
-    .build()
-    .output()
-    .amount()
-    .coin();
+  withCMLScope((own) => {
+    const value = own(assetsToValue(utxo.assets));
+    const builder = own(
+      buildOutput(utxo, own).with_asset_and_min_required_coin(
+        own(value.multi_asset()),
+        coinsPerUtxoByte,
+      ),
+    );
+    const output = own(own(builder.build()).output());
+    return own(output.amount()).coin();
+  });
 
-const buildOutput = (utxo: UTxO): CML.TransactionOutputAmountBuilder => {
-  const builder = CML.TransactionOutputBuilder.new().with_address(
-    CML.Address.from_bech32(utxo.address),
+/**
+ * Every builder stage is a fresh CML object; they are all registered with the
+ * caller's scope so only the caller's final result outlives the conversion.
+ */
+const buildOutput = (
+  utxo: UTxO,
+  own: CMLOwn,
+): CML.TransactionOutputAmountBuilder => {
+  const address = own(CML.Address.from_bech32(utxo.address));
+  const addressed = own(
+    own(CML.TransactionOutputBuilder.new()).with_address(address),
   );
-  return utxo.scriptRef
-    ? buildDatum(utxo, builder)
-        .with_reference_script(toScriptRef(utxo.scriptRef))
-        .next()
-    : buildDatum(utxo, builder).next();
+  const builder = buildDatum(utxo, addressed, own);
+  if (!utxo.scriptRef) return own(builder.next());
+  const scriptRef = own(toScriptRef(utxo.scriptRef));
+  return own(own(builder.with_reference_script(scriptRef)).next());
 };
 
 const buildDatum = (
   utxo: UTxO,
   builder: CML.TransactionOutputBuilder,
+  own: CMLOwn,
 ): CML.TransactionOutputBuilder => {
   // with DatumHash
-  if (utxo.datumHash && utxo.datum)
-    return builder.with_communication_data(
-      CML.PlutusData.from_cbor_hex(utxo.datum),
-    );
+  if (utxo.datumHash && utxo.datum) {
+    const datum = own(CML.PlutusData.from_cbor_hex(utxo.datum));
+    return own(builder.with_communication_data(datum));
+  }
   // with InlineDatum
-  if (utxo.datum)
-    return builder.with_data(
-      CML.DatumOption.new_datum(CML.PlutusData.from_cbor_hex(utxo.datum)),
-    );
+  if (utxo.datum) {
+    const datum = own(CML.PlutusData.from_cbor_hex(utxo.datum));
+    return own(builder.with_data(own(CML.DatumOption.new_datum(datum))));
+  }
   return builder;
 };

--- a/packages/utils/src/value.ts
+++ b/packages/utils/src/value.ts
@@ -1,5 +1,11 @@
 import { Assets, PolicyId, UTxO, Unit } from "@lucid-evolution/core-types";
-import { fromHex, fromText, toHex, toText } from "@lucid-evolution/core-utils";
+import {
+  fromHex,
+  fromText,
+  toHex,
+  toText,
+  withCMLScope,
+} from "@lucid-evolution/core-utils";
 import { CML } from "./core.js";
 import { fromLabel, toLabel } from "./label.js";
 import { pipe } from "effect";
@@ -8,48 +14,55 @@ export function valueToAssets(value: CML.Value): Assets {
   const assets: Assets = {};
   assets["lovelace"] = value.coin();
   if (value.has_multiassets()) {
-    const ma = value.multi_asset();
-    const multiAssets = ma.keys();
-    for (let j = 0; j < multiAssets.len(); j++) {
-      const policy = multiAssets.get(j);
-      const policyAssets = ma.get_assets(policy)!;
-      const assetNames = policyAssets.keys();
-      for (let k = 0; k < assetNames.len(); k++) {
-        const policyAsset = assetNames.get(k);
-        const quantity = policyAssets.get(policyAsset)!;
-        // Note: Using policyAsset.to_js_value() as a work around till AssetName provides to_hex() method
-        // https://github.com/dcSpark/cardano-multiplatform-lib/issues/334
-        const unit = policy.to_hex() + policyAsset.to_js_value();
-        assets[unit] = quantity;
+    withCMLScope((own) => {
+      const ma = own(value.multi_asset());
+      const multiAssets = own(ma.keys());
+      for (let j = 0; j < multiAssets.len(); j++) {
+        const policy = own(multiAssets.get(j));
+        const policyAssets = own(ma.get_assets(policy)!);
+        const assetNames = own(policyAssets.keys());
+        for (let k = 0; k < assetNames.len(); k++) {
+          const policyAsset = own(assetNames.get(k));
+          const quantity = policyAssets.get(policyAsset)!;
+          // Note: Using policyAsset.to_js_value() as a work around till AssetName provides to_hex() method
+          // https://github.com/dcSpark/cardano-multiplatform-lib/issues/334
+          const unit = policy.to_hex() + policyAsset.to_js_value();
+          assets[unit] = quantity;
+        }
       }
-    }
+    });
   }
   return assets;
 }
 
 export function assetsToValue(assets: Assets): CML.Value {
-  const multiAsset = CML.MultiAsset.new();
-  const lovelace = assets["lovelace"] ? BigInt(assets["lovelace"]) : 0n;
-  const units = Object.keys(assets);
-  const policies = Array.from(
-    new Set(
-      units
-        .filter((unit) => unit !== "lovelace")
-        .map((unit) => unit.slice(0, 56)),
-    ),
-  );
-  for (const policy of policies) {
-    const policyUnits = units.filter((unit) => unit.slice(0, 56) === policy);
-    const assetsValue = CML.MapAssetNameToCoin.new();
-    for (const unit of policyUnits) {
-      assetsValue.insert(
-        CML.AssetName.from_hex(unit.slice(56)),
-        BigInt(assets[unit]),
+  return withCMLScope((own) => {
+    const multiAsset = own(CML.MultiAsset.new());
+    const lovelace = assets["lovelace"] ? BigInt(assets["lovelace"]) : 0n;
+    const units = Object.keys(assets);
+    const policies = Array.from(
+      new Set(
+        units
+          .filter((unit) => unit !== "lovelace")
+          .map((unit) => unit.slice(0, 56)),
+      ),
+    );
+    for (const policy of policies) {
+      const policyUnits = units.filter((unit) => unit.slice(0, 56) === policy);
+      const assetsValue = own(CML.MapAssetNameToCoin.new());
+      for (const unit of policyUnits) {
+        assetsValue.insert(
+          own(CML.AssetName.from_hex(unit.slice(56))),
+          BigInt(assets[unit]),
+        );
+      }
+      multiAsset.insert_assets(
+        own(CML.ScriptHash.from_hex(policy)),
+        assetsValue,
       );
     }
-    multiAsset.insert_assets(CML.ScriptHash.from_hex(policy), assetsValue);
-  }
-  return CML.Value.new(lovelace, multiAsset);
+    return CML.Value.new(lovelace, multiAsset);
+  });
 }
 
 /**

--- a/packages/wallet/src/wallet.ts
+++ b/packages/wallet/src/wallet.ts
@@ -1,5 +1,5 @@
 import { getAddressDetails } from "@lucid-evolution/utils";
-import { fromHex } from "@lucid-evolution/core-utils";
+import { fromHex, withCMLScope } from "@lucid-evolution/core-utils";
 import {
   Address,
   KeyHash,
@@ -47,53 +47,62 @@ export function walletFromSeed(
       : new Uint8Array(),
   );
 
-  const accountKey = rootKey
-    .derive(harden(1852))
-    .derive(harden(1815))
-    .derive(harden(accountIndex));
+  return withCMLScope((own) => {
+    own(rootKey);
+    const accountKey = own(
+      own(own(rootKey.derive(harden(1852))).derive(harden(1815))).derive(
+        harden(accountIndex),
+      ),
+    );
+    const paymentKey = own(
+      own(own(accountKey.derive(0)).derive(0)).to_raw_key(),
+    );
+    const stakeKey = own(own(own(accountKey.derive(2)).derive(0)).to_raw_key());
 
-  rootKey.free();
+    const paymentKeyHash = own(own(paymentKey.to_public()).hash());
+    const stakeKeyHash = own(own(stakeKey.to_public()).hash());
 
-  const paymentKey = accountKey.derive(0).derive(0).to_raw_key();
-  const stakeKey = accountKey.derive(2).derive(0).to_raw_key();
+    const networkId = network === "Mainnet" ? 1 : 0;
 
-  const paymentKeyHash = paymentKey.to_public().hash();
-  const stakeKeyHash = stakeKey.to_public().hash();
+    const address =
+      addressType === "Base"
+        ? own(
+            own(
+              CML.BaseAddress.new(
+                networkId,
+                own(CML.Credential.new_pub_key(paymentKeyHash)),
+                own(CML.Credential.new_pub_key(stakeKeyHash)),
+              ),
+            ).to_address(),
+          ).to_bech32(undefined)
+        : own(
+            own(
+              CML.EnterpriseAddress.new(
+                networkId,
+                own(CML.Credential.new_pub_key(paymentKeyHash)),
+              ),
+            ).to_address(),
+          ).to_bech32(undefined);
 
-  const networkId = network === "Mainnet" ? 1 : 0;
+    const rewardAddress =
+      addressType === "Base"
+        ? own(
+            own(
+              CML.RewardAddress.new(
+                networkId,
+                own(CML.Credential.new_pub_key(stakeKeyHash)),
+              ),
+            ).to_address(),
+          ).to_bech32(undefined)
+        : null;
 
-  const address =
-    addressType === "Base"
-      ? CML.BaseAddress.new(
-          networkId,
-          CML.Credential.new_pub_key(paymentKeyHash),
-          CML.Credential.new_pub_key(stakeKeyHash),
-        )
-          .to_address()
-          .to_bech32(undefined)
-      : CML.EnterpriseAddress.new(
-          networkId,
-          CML.Credential.new_pub_key(paymentKeyHash),
-        )
-          .to_address()
-          .to_bech32(undefined);
-
-  const rewardAddress =
-    addressType === "Base"
-      ? CML.RewardAddress.new(
-          networkId,
-          CML.Credential.new_pub_key(stakeKeyHash),
-        )
-          .to_address()
-          .to_bech32(undefined)
-      : null;
-
-  return {
-    address,
-    rewardAddress,
-    paymentKey: paymentKey.to_bech32(),
-    stakeKey: addressType === "Base" ? stakeKey.to_bech32() : null,
-  };
+    return {
+      address,
+      rewardAddress,
+      paymentKey: paymentKey.to_bech32(),
+      stakeKey: addressType === "Base" ? stakeKey.to_bech32() : null,
+    };
+  });
 }
 
 export function discoverOwnUsedTxKeyHashes(
@@ -101,254 +110,15 @@ export function discoverOwnUsedTxKeyHashes(
   ownKeyHashes: Array<KeyHash>,
   ownUtxos: Array<UTxO>,
 ): Array<KeyHash> {
-  const usedKeyHashes = [];
+  return withCMLScope((own) => {
+    const usedKeyHashes = [];
 
-  // key hashes from inputs
-  const inputs = tx.body().inputs();
-  for (let i = 0; i < inputs.len(); i++) {
-    const input = inputs.get(i);
-    const txHash = input.transaction_id().to_hex();
-    const outputIndex = Number(input.index());
-    const utxo = ownUtxos.find(
-      (utxo) => utxo.txHash === txHash && utxo.outputIndex === outputIndex,
-    );
-    if (utxo) {
-      const { paymentCredential } = getAddressDetails(utxo.address);
-      usedKeyHashes.push(paymentCredential?.hash!);
-    }
-  }
-
-  const txBody = tx.body();
-
-  // key hashes from certificates
-  function keyHashFromCert(txBody: CML.TransactionBody) {
-    const certs = txBody.certs();
-    if (!certs) return;
-    for (let i = 0; i < certs.len(); i++) {
-      const cert = certs.get(i);
-      switch (cert.kind()) {
-        case 0:
-          // Key hash not needed for registration
-          break;
-
-        case 1: {
-          const credential = cert.as_stake_deregistration()?.stake_credential();
-          switch (credential?.kind()) {
-            case 0:
-              usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-              break;
-            case 1:
-              usedKeyHashes.push(credential.as_script()?.to_hex());
-              break;
-          }
-          break;
-        }
-        case 2: {
-          //TODO: Missing test
-          const credential = cert.as_stake_delegation()?.stake_credential();
-          if (credential?.kind() === 0) {
-            const keyHash = credential.as_pub_key()?.to_hex();
-            usedKeyHashes.push(keyHash);
-          }
-
-          break;
-        }
-        case 3: {
-          //TODO: Missing test
-          const poolParams = cert.as_pool_registration()?.pool_params()!;
-          const owners = poolParams?.pool_owners();
-          if (!owners) break;
-          for (let i = 0; i < owners.len(); i++) {
-            const keyHash = owners.get(i).to_hex();
-            usedKeyHashes.push(keyHash);
-          }
-          const operator = poolParams.operator().to_hex();
-          usedKeyHashes.push(operator);
-
-          break;
-        }
-
-        case 4: {
-          //TODO: Missing test
-          const operator = cert.as_pool_retirement()?.pool().to_hex();
-          usedKeyHashes.push(operator);
-
-          break;
-        }
-
-        case 6: {
-          //TODO: Missing test
-          const credential = cert.as_unreg_cert()?.stake_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 7: {
-          //TODO: Missing test
-          const credential = cert.as_vote_deleg_cert()?.stake_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 8: {
-          //TODO: Missing test
-          const credential = cert
-            .as_stake_vote_deleg_cert()
-            ?.stake_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 9: {
-          //TODO: Missing test
-          const credential = cert.as_stake_reg_deleg_cert()?.stake_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 10: {
-          //TODO: Missing test
-          const credential = cert.as_vote_reg_deleg_cert()?.stake_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 11: {
-          //TODO: Missing test
-          const credential = cert
-            .as_stake_vote_reg_deleg_cert()
-            ?.stake_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 12: {
-          //TODO: Missing test
-          const credential = cert
-            .as_auth_committee_hot_cert()
-            ?.committee_cold_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 13: {
-          //TODO: Missing test
-          const credential = cert
-            .as_resign_committee_cold_cert()
-            ?.committee_cold_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 14: {
-          //TODO: Missing test
-          const credential = cert.as_reg_drep_cert()?.drep_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 15: {
-          //TODO: Missing test
-          const credential = cert.as_unreg_drep_cert()?.drep_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        case 16: {
-          //TODO: Missing test
-          const credential = cert.as_update_drep_cert()?.drep_credential();
-          if (credential) {
-            usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          }
-          break;
-        }
-
-        default:
-          //TODO: Missing certificates
-          break;
-      }
-    }
-  }
-  if (txBody.certs()) keyHashFromCert(txBody);
-
-  // key hashes from withdrawals
-
-  const withdrawals = txBody.withdrawals();
-  function keyHashFromWithdrawal(withdrawals: CML.MapRewardAccountToCoin) {
-    const rewardAddresses = withdrawals.keys();
-    for (let i = 0; i < rewardAddresses.len(); i++) {
-      const credential = rewardAddresses.get(i).payment();
-      switch (credential.kind()) {
-        case 0:
-          usedKeyHashes.push(credential.as_pub_key()?.to_hex());
-          break;
-        case 1:
-          usedKeyHashes.push(credential.as_script()?.to_hex());
-          break;
-      }
-    }
-  }
-  if (withdrawals) keyHashFromWithdrawal(withdrawals);
-
-  // key hashes from scripts
-  const scripts = tx.witness_set().native_scripts();
-  function keyHashFromScript(scripts: CML.NativeScriptList) {
-    for (let i = 0; i < scripts.len(); i++) {
-      const script = scripts.get(i);
-      if (script.kind() === 0) {
-        const keyHash = script.as_script_pubkey()?.ed25519_key_hash().to_hex();
-        usedKeyHashes.push(keyHash);
-      }
-      if (script.kind() === 1) {
-        keyHashFromScript(script.as_script_all()!.native_scripts());
-        return;
-      }
-      if (script.kind() === 2) {
-        keyHashFromScript(script.as_script_any()!.native_scripts());
-        return;
-      }
-      if (script.kind() === 3) {
-        keyHashFromScript(script.as_script_n_of_k()!.native_scripts());
-        return;
-      }
-    }
-  }
-  if (scripts) keyHashFromScript(scripts);
-
-  // keyHashes from required signers
-  const requiredSigners = txBody.required_signers();
-  if (requiredSigners) {
-    for (let i = 0; i < requiredSigners.len(); i++) {
-      usedKeyHashes.push(requiredSigners.get(i).to_hex());
-    }
-  }
-
-  // keyHashes from collateral
-  const collateral = txBody.collateral_inputs();
-  if (collateral) {
-    for (let i = 0; i < collateral.len(); i++) {
-      const input = collateral.get(i);
-      const txHash = input.transaction_id().to_hex();
+    // key hashes from inputs
+    const txBody = own(tx.body());
+    const inputs = own(txBody.inputs());
+    for (let i = 0; i < inputs.len(); i++) {
+      const input = own(inputs.get(i));
+      const txHash = own(input.transaction_id()).to_hex();
       const outputIndex = Number(input.index());
       const utxo = ownUtxos.find(
         (utxo) => utxo.txHash === txHash && utxo.outputIndex === outputIndex,
@@ -358,7 +128,277 @@ export function discoverOwnUsedTxKeyHashes(
         usedKeyHashes.push(paymentCredential?.hash!);
       }
     }
-  }
 
-  return usedKeyHashes.filter((k) => ownKeyHashes.includes(k));
+    // key hashes from certificates
+    function keyHashFromCert(txBody: CML.TransactionBody) {
+      const certs = own(txBody.certs());
+      if (!certs) return;
+      for (let i = 0; i < certs.len(); i++) {
+        const cert = own(certs.get(i));
+        switch (cert.kind()) {
+          case 0:
+            // Key hash not needed for registration
+            break;
+
+          case 1: {
+            const credential = own(
+              own(cert.as_stake_deregistration())?.stake_credential(),
+            );
+            switch (credential?.kind()) {
+              case 0:
+                usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+                break;
+              case 1:
+                usedKeyHashes.push(own(credential.as_script())?.to_hex());
+                break;
+            }
+            break;
+          }
+          case 2: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_stake_delegation())?.stake_credential(),
+            );
+            if (credential?.kind() === 0) {
+              const keyHash = own(credential.as_pub_key())?.to_hex();
+              usedKeyHashes.push(keyHash);
+            }
+
+            break;
+          }
+          case 3: {
+            //TODO: Missing test
+            const poolParams = own(
+              own(cert.as_pool_registration())?.pool_params(),
+            )!;
+            const owners = own(poolParams?.pool_owners());
+            if (!owners) break;
+            for (let i = 0; i < owners.len(); i++) {
+              const keyHash = own(owners.get(i)).to_hex();
+              usedKeyHashes.push(keyHash);
+            }
+            const operator = own(poolParams.operator()).to_hex();
+            usedKeyHashes.push(operator);
+
+            break;
+          }
+
+          case 4: {
+            //TODO: Missing test
+            const operator = own(
+              own(cert.as_pool_retirement())?.pool(),
+            )?.to_hex();
+            usedKeyHashes.push(operator);
+
+            break;
+          }
+
+          case 6: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_unreg_cert())?.stake_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 7: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_vote_deleg_cert())?.stake_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 8: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_stake_vote_deleg_cert())?.stake_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 9: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_stake_reg_deleg_cert())?.stake_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 10: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_vote_reg_deleg_cert())?.stake_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 11: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_stake_vote_reg_deleg_cert())?.stake_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 12: {
+            //TODO: Missing test
+            const credential = own(
+              own(
+                cert.as_auth_committee_hot_cert(),
+              )?.committee_cold_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 13: {
+            //TODO: Missing test
+            const credential = own(
+              own(
+                cert.as_resign_committee_cold_cert(),
+              )?.committee_cold_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 14: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_reg_drep_cert())?.drep_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 15: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_unreg_drep_cert())?.drep_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          case 16: {
+            //TODO: Missing test
+            const credential = own(
+              own(cert.as_update_drep_cert())?.drep_credential(),
+            );
+            if (credential) {
+              usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            }
+            break;
+          }
+
+          default:
+            //TODO: Missing certificates
+            break;
+        }
+      }
+    }
+    keyHashFromCert(txBody);
+
+    // key hashes from withdrawals
+
+    const withdrawals = own(txBody.withdrawals());
+    function keyHashFromWithdrawal(withdrawals: CML.MapRewardAccountToCoin) {
+      const rewardAddresses = own(withdrawals.keys());
+      for (let i = 0; i < rewardAddresses.len(); i++) {
+        const credential = own(own(rewardAddresses.get(i)).payment());
+        switch (credential.kind()) {
+          case 0:
+            usedKeyHashes.push(own(credential.as_pub_key())?.to_hex());
+            break;
+          case 1:
+            usedKeyHashes.push(own(credential.as_script())?.to_hex());
+            break;
+        }
+      }
+    }
+    if (withdrawals) keyHashFromWithdrawal(withdrawals);
+
+    // key hashes from scripts
+    const scripts = own(own(tx.witness_set()).native_scripts());
+    function keyHashFromScript(scripts: CML.NativeScriptList) {
+      for (let i = 0; i < scripts.len(); i++) {
+        const script = own(scripts.get(i));
+        if (script.kind() === 0) {
+          const keyHash = own(
+            own(script.as_script_pubkey())?.ed25519_key_hash(),
+          )?.to_hex();
+          usedKeyHashes.push(keyHash);
+        }
+        if (script.kind() === 1) {
+          keyHashFromScript(own(own(script.as_script_all())!.native_scripts()));
+          return;
+        }
+        if (script.kind() === 2) {
+          keyHashFromScript(own(own(script.as_script_any())!.native_scripts()));
+          return;
+        }
+        if (script.kind() === 3) {
+          keyHashFromScript(
+            own(own(script.as_script_n_of_k())!.native_scripts()),
+          );
+          return;
+        }
+      }
+    }
+    if (scripts) keyHashFromScript(scripts);
+
+    // keyHashes from required signers
+    const requiredSigners = own(txBody.required_signers());
+    if (requiredSigners) {
+      for (let i = 0; i < requiredSigners.len(); i++) {
+        usedKeyHashes.push(own(requiredSigners.get(i)).to_hex());
+      }
+    }
+
+    // keyHashes from collateral
+    const collateral = own(txBody.collateral_inputs());
+    if (collateral) {
+      for (let i = 0; i < collateral.len(); i++) {
+        const input = own(collateral.get(i));
+        const txHash = own(input.transaction_id()).to_hex();
+        const outputIndex = Number(input.index());
+        const utxo = ownUtxos.find(
+          (utxo) => utxo.txHash === txHash && utxo.outputIndex === outputIndex,
+        );
+        if (utxo) {
+          const { paymentCredential } = getAddressDetails(utxo.address);
+          usedKeyHashes.push(paymentCredential?.hash!);
+        }
+      }
+    }
+
+    return usedKeyHashes.filter((k) => ownKeyHashes.includes(k));
+  });
 }

--- a/packages/wallet/src/wallet_selection.ts
+++ b/packages/wallet/src/wallet_selection.ts
@@ -15,7 +15,7 @@ import {
   Wallet,
   WalletApi,
 } from "@lucid-evolution/core-types";
-import { fromHex, toHex } from "@lucid-evolution/core-utils";
+import { fromHex, toHex, withCMLScope } from "@lucid-evolution/core-utils";
 import {
   coreToUtxo,
   credentialToRewardAddress,
@@ -132,17 +132,15 @@ export const makeWalletFromSeed = (
 
     const usedKeyHashes = discoverOwnUsedTxKeyHashes(tx, ownKeyHashes, utxos);
 
-    const txWitnessSetBuilder = CML.TransactionWitnessSetBuilder.new();
-    for (const keyHash of usedKeyHashes) {
-      const priv = CML.PrivateKey.from_bech32(privKeyHashMap[keyHash]!);
-      const witness = CML.make_vkey_witness(
-        CML.hash_transaction(tx.body()),
-        priv,
-      );
-      txWitnessSetBuilder.add_vkey(witness);
-    }
-
-    return txWitnessSetBuilder.build();
+    return withCMLScope((own) => {
+      const txWitnessSetBuilder = own(CML.TransactionWitnessSetBuilder.new());
+      const txHash = own(CML.hash_transaction(own(tx.body())));
+      for (const keyHash of usedKeyHashes) {
+        const priv = own(CML.PrivateKey.from_bech32(privKeyHashMap[keyHash]!));
+        txWitnessSetBuilder.add_vkey(own(CML.make_vkey_witness(txHash, priv)));
+      }
+      return txWitnessSetBuilder.build();
+    });
   };
   return {
     overrideUTxOs: (utxos: UTxO[]) => (config.overriddenUTxOs = utxos),
@@ -223,13 +221,14 @@ export const makeWalletFromPrivateKey = (
   const signTx = async (
     tx: CML.Transaction,
   ): Promise<CML.TransactionWitnessSet> => {
-    const witness = CML.make_vkey_witness(
-      CML.hash_transaction(tx.body()),
-      priv,
-    );
-    const txWitnessSetBuilder = CML.TransactionWitnessSetBuilder.new();
-    txWitnessSetBuilder.add_vkey(witness);
-    return txWitnessSetBuilder.build();
+    return withCMLScope((own) => {
+      const witness = own(
+        CML.make_vkey_witness(own(CML.hash_transaction(own(tx.body()))), priv),
+      );
+      const txWitnessSetBuilder = own(CML.TransactionWitnessSetBuilder.new());
+      txWitnessSetBuilder.add_vkey(witness);
+      return txWitnessSetBuilder.build();
+    });
   };
 
   return {


### PR DESCRIPTION
## Problem

Every CML value is a wasm-bindgen wrapper around an allocation in the CML wasm linear memory. That allocation is only released by `free()`, either explicitly or from the `FinalizationRegistry` cleanup that runs after a *major* JavaScript GC. lucid-evolution never called `free()`, so the wasm arena kept every transaction, output, script and datum that was ever decoded until a major GC happened to run. The wrappers themselves are tiny, so the JS heap stays small and V8 rarely runs one.

In a process that builds many transactions (an emulator test suite, a long-running submitter) this shows up as external memory growing by ~150 MB per transaction journey; once it exceeds V8's external-memory limit, every further allocation triggers a full compacting GC. In our fault-proof emulator suite a 4-second test took 120–180 s once enough transactions had been built in the same process, with 115 of 119 profiled seconds spent in GC.

## Fix

Explicit ownership across the builder, signer, emulator, wallet and utils:

- a function frees every CML object it creates and does not return;
- CML arguments are borrowed (CML clones whatever it keeps), so the caller frees them after the call;
- a returned CML object belongs to the caller.

`withCMLScope((own) => …)` and `freeCML(...)` in `@lucid-evolution/core-utils` keep that tidy where a chain of temporaries is built; everything registered with `own` is freed in reverse order when the scope body returns or throws.

The CML entry points that take ownership of an argument are left un-freed and commented at each call site: `Transaction.new` takes the auxiliary data, `SingleMintBuilder.native_script` / `plutus_script` take the builder, `TransactionWitnessSetBuilder.add_plutus_datum` takes the datum. Objects that reach user code (the completed `Transaction`, `TxSignBuilder`'s witness-set builder, the signed transaction, the `RedeemerContext` body while a redeemer builder runs) are not freed.

Two structural changes remove lifetime juggling instead of adding it: the map of builder redeemer keys stores plain `(tag, index)` pairs rather than `RedeemerWitnessKey` objects, and each delayed-redeemer replay frees its `TransactionBuilder` once the attempt's transaction has been copied out.

Also fixed on the way: the emulator's `evaluateTx` read the redeemer index as `Number(key.index)` (the method, not the value); it now calls `key.index()`.

## Measurement

On one emulator journey file (7 lifecycle tests, each building and submitting several transactions):

| | before | after |
|---|---|---|
| CML objects created | ~87k per journey | unchanged |
| freed explicitly | ~0.3% | 97% |
| CML wasm arena at end of file | 388 MB | 65 MiB |

All package test suites pass (`utils`, `plutus`, `provider`, `wallet`, `lucid`), `tsc --noEmit` is clean for the touched packages (`provider`'s pre-existing test-file errors aside), `pnpm format-check` passes. Our downstream fault-proof suite (295 files) produces an identical result set with the old and new dists.


## CI

The first run of this PR failed in `test/onchain-preprod.test.ts` (`Read Reference Input Twice`, `MultiValidator - registerStake`, `MultiValidator - mintAndWithdrawSimpleStake`) with `ConwayMempoolFailure "All inputs are spent"`. The same suite failed the same way on the last three pushes to `main`. The cause is not the code under test: the on-chain tests spend from one shared preprod wallet, and the PR run overlapped a still-running `main` job (run 33819399226 was submitting from that wallet until 01:10 UTC while this run's on-chain tests started at 01:00). Two runs building from the same UTxO set spend each other's inputs, and every retry fails until the other run finishes.

The second commit puts the CI job in a concurrency group so runs queue instead of racing, and gives `readRefInputTwice` the same retry and cause logging as every other spec.
